### PR TITLE
Add SDLLib as submodule and use modified version of biggestDump's console.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Set the default behavior for all files.
+* text=auto eol=lf
+
+# Normalized and converts to native line endings on checkout.
+*.c text
+*.cc text
+*.cxx
+*.cpp text
+*.h text
+*.hxx text
+*.hpp text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.vscode/
+*.lst
+.clang-format
+.clang-tidy
+.editorconfig
+*.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/SDLLib"]
+	path = libs/SDLLib
+	url = https://github.com/J-D-K/SDLLib.git

--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -92,6 +92,14 @@ class Console
             Instance.Render();
         }
 
+        static void Reset(void)
+        {
+            Console &Instance = Console::GetInstance();
+
+            Instance.m_LineCount = 0;
+            Instance.m_ConsoleText.clear();
+        }
+
     private:
         // No constructing.
         Console(void) = default;

--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -5,8 +5,6 @@
 #include <cstring>
 #include <string>
 
-#include "Logger.hpp"
-
 /*
     biggestDump's console but modified.
 */
@@ -74,13 +72,10 @@ class Console
                     CurrentLinePosition = Instance.m_ConsoleText.find_first_of('\n', CurrentLinePosition) + 1;
                     if (CurrentLinePosition != Instance.m_ConsoleText.npos)
                     {
-                        Logger::Log("Erase.");
                         Instance.m_ConsoleText.erase(0, CurrentLinePosition);
                     }
                     else
                     {
-                        // If it's npos, no point in continuing loop.
-                        Logger::Log("Break");
                         break;
                     }
                     ++CurrentLinePosition;

--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -64,7 +64,7 @@ class Console
             Instance.m_LineCount += NewLineCount;
 
             // This is to actually delete that many lines from the Console's string.
-            if (Instance.m_LineCount > Instance.m_MaxLineCount)
+            if (Instance.m_LineCount >= Instance.m_MaxLineCount)
             {
                 // Number of lines to trim
                 size_t LinesToTrim = Instance.m_LineCount - Instance.m_MaxLineCount;

--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -1,0 +1,127 @@
+#pragma once
+#include "SDL.hpp"
+#include <cstdarg>
+#include <cstddef>
+#include <cstring>
+#include <string>
+
+#include "Logger.hpp"
+
+/*
+    biggestDump's console but modified.
+*/
+
+class Console
+{
+    public:
+        // No copying.
+        Console(const Console &) = delete;
+        Console(Console &&) = delete;
+        Console &operator=(const Console &) = delete;
+        Console &operator=(Console &&) = delete;
+
+        static void SetMaxLineCount(size_t MaxLineCount)
+        {
+            Console &Instance = Console::GetInstance();
+
+            Instance.m_MaxLineCount = MaxLineCount;
+        }
+
+        static void SetFontSize(int FontSize)
+        {
+            Console &Instance = Console::GetInstance();
+
+            Instance.m_FontSize = FontSize;
+        }
+
+        static void SetClearColor(SDL::Color Color)
+        {
+            Console &Instance = Console::GetInstance();
+
+            Instance.m_ClearColor = Color;
+        }
+
+        // I considered rendering tricks to accomplish this, but this is easier.
+        static void Printf(const char *Format, ...)
+        {
+            Console &Instance = Console::GetInstance();
+
+            char VaBuffer[0x1000];
+            std::va_list VaList;
+            va_start(VaList, Format);
+            vsnprintf(VaBuffer, 0x1000, Format, VaList);
+            va_end(VaList);
+
+            // This is to get count of how many lines to remove.
+            size_t NewLineCount = 0;
+            char *NewLineSearch = VaBuffer;
+            while ((NewLineSearch = std::strchr(NewLineSearch, '\n')) != NULL)
+            {
+                ++NewLineCount;
+                ++NewLineSearch;
+            }
+
+            Instance.m_LineCount += NewLineCount;
+
+            // This is to actually delete that many lines from the Console's string.
+            if (Instance.m_LineCount > Instance.m_MaxLineCount)
+            {
+                // Number of lines to trim
+                size_t LinesToTrim = Instance.m_LineCount - Instance.m_MaxLineCount;
+
+                for (size_t i = 0, CurrentLinePosition = 0; i < LinesToTrim; i++)
+                {
+                    CurrentLinePosition = Instance.m_ConsoleText.find_first_of('\n', CurrentLinePosition) + 1;
+                    if (CurrentLinePosition != Instance.m_ConsoleText.npos)
+                    {
+                        Logger::Log("Erase.");
+                        Instance.m_ConsoleText.erase(0, CurrentLinePosition);
+                    }
+                    else
+                    {
+                        // If it's npos, no point in continuing loop.
+                        Logger::Log("Break");
+                        break;
+                    }
+                    ++CurrentLinePosition;
+                    Instance.m_LineCount -= LinesToTrim;
+                }
+            }
+            // Append buffer to console output.
+            Instance.m_ConsoleText += VaBuffer;
+            Instance.Render();
+        }
+
+    private:
+        // No constructing.
+        Console(void) = default;
+        // Returns the only instance of console.
+        static Console &GetInstance(void)
+        {
+            static Console Instance;
+            return Instance;
+        }
+        // This is the render function. Normally this would be public, but in this case, we don't want it called outside of the class.
+        static void Render(void)
+        {
+            Console &Instance = Console::GetInstance();
+
+            // This is modified from how biggestDump does this. Since we want this to act like a normal console.
+            // Unlike biggestDump, this will render the console and update the screen immediately. biggestDump is threaded.
+            SDL::FrameBegin(Instance.m_ClearColor);
+            // You can change the X and Y to whatever you want. Just remember to adjust max lines and size to match.
+            // This version will wrap text, but can have some issues the console isn't aware of. The one below it doesn't wrap.
+            // SDL::Text::Render(NULL, 8, 8, Instance.m_FontSize, 1264, {0xFFFFFFFF}, Instance.m_ConsoleText.c_str());
+            SDL::Text::Render(NULL, 8, 8, Instance.m_FontSize, SDL::Text::NO_TEXT_WRAP, {0xFFFFFFFF}, Instance.m_ConsoleText.c_str());
+            SDL::FrameEnd();
+        }
+        // Number of lines before we stand cutting them off.
+        size_t m_LineCount = 0;
+        size_t m_MaxLineCount = 0;
+        // Font size used to render text. Default is 20, but this can be changed by calling SetFontSize.
+        int m_FontSize = 20;
+        // This is the color used to clear the background. By default it is black.
+        SDL::Color m_ClearColor = {0x00000000};
+        // Actual text being displayed.
+        std::string m_ConsoleText;
+};

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,0 +1,7 @@
+#pragma once 
+
+namespace Logger
+{
+    void Initialize(void);
+    void Log(const char *Format, ...);
+}

--- a/include/asmInterpreter.hpp
+++ b/include/asmInterpreter.hpp
@@ -1,13 +1,17 @@
 #pragma once
-#include <vector>
-#include <cstddef>
-#include <string>
-#include <cstring>
-#include <algorithm>
 #include "dmntcht.h"
-extern "C" {
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <string>
+#include <vector>
+extern "C"
+{
 #include "armadillo.h"
 #include "strext.h"
 }
 
-void dumpPointers(std::vector<std::string> UnityNames, std::vector<uint32_t> UnityOffsets, DmntCheatProcessMetadata cheatMetadata, std::string unity_sdk);
+void dumpPointers(const std::vector<std::string> &UnityNames,
+                  const std::vector<uint32_t> &UnityOffsets,
+                  DmntCheatProcessMetadata cheatMetadata,
+                  const std::string &unity_sdk);

--- a/include/asmInterpreter.hpp
+++ b/include/asmInterpreter.hpp
@@ -13,5 +13,5 @@ extern "C"
 
 void dumpPointers(const std::vector<std::string> &UnityNames,
                   const std::vector<uint32_t> &UnityOffsets,
-                  DmntCheatProcessMetadata cheatMetadata,
+                  const DmntCheatProcessMetadata &cheatMetadata,
                   const std::string &unity_sdk);

--- a/libs/armadillo/example.c
+++ b/libs/armadillo/example.c
@@ -1329,7 +1329,7 @@ static const char *GET_FP_REG(const char **rtbl, unsigned int idx){
 }
 
 static void disp_operand(struct ad_operand operand){
-    printf("\t\tThis operand is of type %s\n", AD_TYPE_TABLE[operand.type]);
+    Console::Console::Printf("\t\tThis operand is of type %s\n", AD_TYPE_TABLE[operand.type]);
 
     if(operand.type == AD_OP_REG){
         if(operand.op_reg.sysreg != AD_NONE){

--- a/source/Logger.cpp
+++ b/source/Logger.cpp
@@ -1,0 +1,29 @@
+#include "Logger.hpp"
+#include <cstdarg>
+#include <fstream>
+
+namespace
+{
+    // This is the hardcoded path for the log so I can debug stuff.
+    const char *LogPath = "sdmc:/switch/UnityFuncDumper.log"; // This is the size of the buffer used for va args.
+    constexpr size_t LOG_BUFFER_SIZE = 0x1000;
+} // namespace
+
+void Logger::Initialize(void)
+{
+    // This will just open this for writing to make sure it exists.
+    std::ofstream LogFile(LogPath);
+}
+
+void Logger::Log(const char *Format, ...)
+{
+    char VaBuffer[LOG_BUFFER_SIZE] = {0};
+
+    std::va_list VaList;
+    va_start(VaList, Format);
+    vsnprintf(VaBuffer, LOG_BUFFER_SIZE, Format, VaList);
+    va_end(VaList);
+    // This will output the string and flush the file immediately in the event of a crash.
+    std::ofstream LogFile(LogPath, std::ios::app);
+    LogFile << VaBuffer << std::endl;
+}

--- a/source/asmInterpreter.cpp
+++ b/source/asmInterpreter.cpp
@@ -42,7 +42,7 @@ struct pointerDump
 
 void dumpPointers(const std::vector<std::string> &UnityNames,
                   const std::vector<uint32_t> &UnityOffsets,
-                  const DmntCheatProcessMetadata cheatMetadata,
+                  const DmntCheatProcessMetadata &cheatMetadata,
                   const std::string &unity_sdk)
 {
     ad_insn *insn = NULL;
@@ -55,7 +55,7 @@ void dumpPointers(const std::vector<std::string> &UnityNames,
         auto itr = std::find(UnityNames.begin(), UnityNames.end(), unityDataStruct[i].search_name);
         if (itr == UnityNames.end())
         {
-            Console::Printf("%s was not found!\n", unityDataStruct[i].search_name);
+            Console::Printf(">%s was not found!>\n", unityDataStruct[i].search_name);
             continue;
         }
         size_t index = itr - UnityNames.begin();
@@ -74,7 +74,7 @@ void dumpPointers(const std::vector<std::string> &UnityNames,
             int rc = ArmadilloDisassemble(instruction, start_address, &insn);
             if (rc)
             {
-                Console::Printf("Disassembler error! 0x%x/%d\n", rc, rc);
+                Console::Printf(">Disassembler error! 0x%x/%d>\n", rc, rc);
                 ArmadilloDone(&insn);
                 return;
             }
@@ -507,7 +507,7 @@ void dumpPointers(const std::vector<std::string> &UnityNames,
     Console::Printf("Results: %ld\n", result.size());
     if (!text_file)
     {
-        Console::Printf("Couldn't create txt file!\n");
+        Console::Printf(">Couldn't create txt file!>\n");
     }
     else
     {
@@ -542,6 +542,6 @@ void dumpPointers(const std::vector<std::string> &UnityNames,
         // Console::Printf("Dumped instructions to txt file:\n");
         // Console::Printf(path);
         // Console::Printf("\n");
-        Console::Printf("Dumped instructions to txt file: %s\n", path);
+        Console::Printf("Dumped instructions to txt file: *%s*\n", path);
     }
 }

--- a/source/asmInterpreter.cpp
+++ b/source/asmInterpreter.cpp
@@ -40,10 +40,10 @@ struct pointerDump
         std::string register_print;
 };
 
-void dumpPointers(const std::vector<std::string> UnityNames,
-                  const std::vector<uint32_t> UnityOffsets,
+void dumpPointers(const std::vector<std::string> &UnityNames,
+                  const std::vector<uint32_t> &UnityOffsets,
                   const DmntCheatProcessMetadata cheatMetadata,
-                  std::string unity_sdk)
+                  const std::string &unity_sdk)
 {
     ad_insn *insn = NULL;
     MachineState machineState = {0};
@@ -538,10 +538,10 @@ void dumpPointers(const std::vector<std::string> UnityNames,
                 fwrite("\n", 1, 1, text_file);
         }
         fclose(text_file);
-        Console::Printf("Dumped instructions to txt file:\n");
-        Console::Printf(path);
-        Console::Printf("\n");
+        // Seriously?
+        // Console::Printf("Dumped instructions to txt file:\n");
+        // Console::Printf(path);
+        // Console::Printf("\n");
+        Console::Printf("Dumped instructions to txt file: %s\n", path);
     }
-    result.clear();
-    forPass.clear();
 }

--- a/source/asmInterpreter.cpp
+++ b/source/asmInterpreter.cpp
@@ -1,24 +1,31 @@
 #include "asmInterpreter.hpp"
+#include "Console.hpp"
 #include "UnityDumps.hpp"
 
-void wrongOperand(ad_insn* insn, const DmntCheatProcessMetadata cheatMetadata, uint64_t address) {
-	printf("Unsupported instruction! %s\n", insn -> decoded);
-	printf("offset: 0x%lx\n", address - cheatMetadata.main_nso_extents.base);
-	printf("Operands:\n");
-	for (int i = 0; i < insn -> num_operands; i++) {
-		printf("%d. type: ", i);
-		if (insn -> operands[i].type == AD_OP_REG) {
-			printf("REG: %s\n", insn -> operands[i].op_reg.rtbl[0]);
-		}
-		else if (insn -> operands[i].type == AD_OP_IMM) {
-			printf("IMM: 0x%lx\n", insn -> operands[i].op_imm.bits);
-		}
-		else if (insn -> operands[i].type == AD_OP_SHIFT) {
-			printf("SHIFT: type: %d, amt: %d\n", insn -> operands[i].op_shift.type, insn -> operands[i].op_shift.amt);
-		}
-		else printf("MEM\n");
-	}
-	ArmadilloDone(&insn);
+void wrongOperand(ad_insn *insn, const DmntCheatProcessMetadata cheatMetadata, uint64_t address)
+{
+    Console::Printf("Unsupported instruction! %s\n", insn->decoded);
+    Console::Printf("offset: 0x%lx\n", address - cheatMetadata.main_nso_extents.base);
+    Console::Printf("Operands:\n");
+    for (int i = 0; i < insn->num_operands; i++)
+    {
+        Console::Printf("%d. type: ", i);
+        if (insn->operands[i].type == AD_OP_REG)
+        {
+            Console::Printf("REG: %s\n", insn->operands[i].op_reg.rtbl[0]);
+        }
+        else if (insn->operands[i].type == AD_OP_IMM)
+        {
+            Console::Printf("IMM: 0x%lx\n", insn->operands[i].op_imm.bits);
+        }
+        else if (insn->operands[i].type == AD_OP_SHIFT)
+        {
+            Console::Printf("SHIFT: type: %d, amt: %d\n", insn->operands[i].op_shift.type, insn->operands[i].op_shift.amt);
+        }
+        else
+            Console::Printf("MEM\n");
+    }
+    ArmadilloDone(&insn);
 }
 
 MachineState machineState_copy = {0};
@@ -26,381 +33,515 @@ int registerPointer = 0;
 long immediate_offset = 0;
 bool cmp_flag = false;
 
-struct pointerDump {
-	UnityData* data;
-	std::string toPrint;
-	std::string register_print;
+struct pointerDump
+{
+        UnityData *data;
+        std::string toPrint;
+        std::string register_print;
 };
 
-void dumpPointers(const std::vector<std::string> UnityNames, const std::vector<uint32_t> UnityOffsets, const DmntCheatProcessMetadata cheatMetadata, std::string unity_sdk) {
-	ad_insn *insn = NULL;
-	MachineState machineState = {0};
-	std::vector<pointerDump> result;
-	std::vector<std::string> forPass;
-	for (size_t i = 0; i < unityDataStruct.size(); i++) {
-		forPass.clear();
-		auto itr = std::find(UnityNames.begin(), UnityNames.end(), unityDataStruct[i].search_name);
-		if (itr == UnityNames.end()) {
-			printf("%s was not found!\n", unityDataStruct[i].search_name);
-			consoleUpdate(NULL);
-			continue;
-		}
-		size_t index = itr - UnityNames.begin();
-		uint64_t start_address = cheatMetadata.main_nso_extents.base + UnityOffsets[index];
-		uint32_t instruction = 0;
-		std::vector<uint64_t> returns;
-		while(true) {
-			dmntchtReadCheatProcessMemory(start_address, (void*)&instruction, sizeof(uint32_t));
-			if (returns.size() == 0 && instruction == 0xD65F03C0)
-				break;
-			if (insn) {
-				ArmadilloDone(&insn);
-			}
-			int rc = ArmadilloDisassemble(instruction, start_address, &insn);
-			if (rc) {
-				printf("Disassembler error! 0x%x/%d\n", rc, rc);
-				ArmadilloDone(&insn);
-				return;
-			}
-			else {
-				forPass.push_back(insn -> decoded);
-			}
-			uint8_t readSize = 0;
-			switch(insn -> instr_id) {
-				case AD_INSTR_ADD: {
-					if (insn -> operands[2].type == AD_OP_REG) {
-						machineState.X[insn -> operands[0].op_reg.rn] = machineState.X[insn -> operands[1].op_reg.rn] + machineState.X[insn -> operands[2].op_reg.rn];
-					}
-					else if (insn -> operands[2].type == AD_OP_IMM) {
-						machineState.X[insn -> operands[0].op_reg.rn] = machineState.X[insn -> operands[1].op_reg.rn] + insn -> operands[2].op_imm.bits;
-					}
-					else {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;						
-					}
-					break;
-				}
-				case AD_INSTR_ADRP: {
-					machineState.X[insn -> operands[0].op_reg.rn] = insn -> operands[1].op_imm.bits;
-					break;
-				}
-				case AD_INSTR_B: {
-					start_address = insn -> operands[0].op_imm.bits - 4;
-					break;
-				}
-				case AD_INSTR_BL: {
-					if (insn -> num_operands != 1) {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;									
-					}
-					returns.push_back(start_address);
-					start_address = insn -> operands[0].op_imm.bits - 4;
-					break;
-				}
-				case AD_INSTR_BR: {
-					start_address = machineState.X[insn -> operands[0].op_reg.rn] - 4;
-					break;
-				}
-				case AD_INSTR_CMP: {
-					cmp_flag = machineState.X[insn -> operands[0].op_reg.rn] == machineState.X[insn -> operands[1].op_reg.rn];
-					break;
-				}
-				case AD_INSTR_LDP: {
-					break;
-				}
-				case AD_INSTR_LDRB:
-					readSize = 1;
-				case AD_INSTR_LDRH:
-					if (!readSize) readSize = 2;
-				case AD_INSTR_LDR: {
-					if (insn -> num_operands == 4) {
-						if (insn -> operands[0].op_reg.fp) {
-							if ((insn -> operands[3].type != AD_OP_IMM) || (insn -> operands[3].op_imm.bits < 0)) {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-							if (insn -> operands[0].op_reg.rtbl[0][0] == 's') {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (machineState.X[insn -> operands[2].op_reg.rn] << insn -> operands[3].op_imm.bits), (void*)&machineState.S[insn -> operands[0].op_reg.rn], sizeof(uint64_t));
-							}
-							else if (insn -> operands[0].op_reg.rtbl[0][0] == 'd') {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (machineState.X[insn -> operands[2].op_reg.rn] << insn -> operands[3].op_imm.bits), (void*)&machineState.D[insn -> operands[0].op_reg.rn], sizeof(uint64_t));
-							}
-							else {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-						}
-						else {
-							if ((insn -> operands[3].type != AD_OP_IMM) || (insn -> operands[3].op_imm.bits < 0)) {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-							if (insn -> operands[0].op_reg.rtbl[0][0] == 'w') {
-								machineState.X[insn -> operands[0].op_reg.rn] = 0;
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (machineState.X[insn -> operands[2].op_reg.rn] << insn -> operands[3].op_imm.bits), (void*)&machineState.X[insn -> operands[0].op_reg.rn], (readSize ? readSize : sizeof(uint32_t)));
-							}
-							else if (insn -> operands[0].op_reg.rtbl[0][0] == 'x')  {
-								machineState.X[insn -> operands[0].op_reg.rn] = 0;
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (machineState.X[insn -> operands[2].op_reg.rn] << insn -> operands[3].op_imm.bits), (void*)&machineState.X[insn -> operands[0].op_reg.rn], (readSize ? readSize : sizeof(uint64_t)));
-							}
-							else {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-						}
-					}
-					
-					else if (insn -> num_operands == 3) {
-						if (insn -> operands[0].op_reg.fp) {
-							if (insn -> operands[0].op_reg.rtbl[0][0] == 's') {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (insn -> operands[2].op_imm.bits), (void*)&machineState.S[insn -> operands[0].op_reg.rn], sizeof(uint64_t));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = insn -> operands[2].op_imm.bits;
-								}
-							}
-							else if (insn -> operands[0].op_reg.rtbl[0][0] == 'd') {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (insn -> operands[2].op_imm.bits), (void*)&machineState.D[insn -> operands[0].op_reg.rn], sizeof(uint64_t));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = insn -> operands[2].op_imm.bits;
-								}
-							}
-							else {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-						}
-						else {
-							if (insn -> operands[0].op_reg.rtbl[0][0] == 'w') {
-								machineState.X[insn -> operands[0].op_reg.rn] = 0;
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (insn -> operands[2].op_imm.bits), (void*)&machineState.X[insn -> operands[0].op_reg.rn], (readSize ? readSize : sizeof(uint32_t)));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = insn -> operands[2].op_imm.bits;
-								}
-							}
-							else if (insn -> operands[0].op_reg.rtbl[0][0] == 'x')  {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (insn -> operands[2].op_imm.bits), (void*)&machineState.X[insn -> operands[0].op_reg.rn], (readSize ? readSize : sizeof(uint64_t)));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = insn -> operands[2].op_imm.bits;
-								}
-							}
-							else {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-						}
-					}
-					else if (insn -> num_operands == 2) {
-						if (insn -> operands[0].op_reg.fp) {
-							if (insn -> operands[0].op_reg.rtbl[0][0] == 's') {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn], (void*)&machineState.S[insn -> operands[0].op_reg.rn], sizeof(uint64_t));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = 0;
-								}
-							}
-							else if (insn -> operands[0].op_reg.rtbl[0][0] == 'd') {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn], (void*)&machineState.D[insn -> operands[0].op_reg.rn], sizeof(uint64_t));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = 0;
-								}
-							}
-							else {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-						}
-						else {
-							if (insn -> operands[0].op_reg.rtbl[0][0] == 'w') {
-								machineState.X[insn -> operands[0].op_reg.rn] = 0;
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn], (void*)&machineState.X[insn -> operands[0].op_reg.rn], (readSize ? readSize : sizeof(uint32_t)));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = 0;
-								}
-							}
-							else if (insn -> operands[0].op_reg.rtbl[0][0] == 'x') {
-								dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn], (void*)&machineState.X[insn -> operands[0].op_reg.rn], (readSize ? readSize : sizeof(uint64_t)));
-								if (insn -> operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn -> operands[0].op_reg.rn == 0) {
-									memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
-									registerPointer = insn -> operands[1].op_reg.rn;
-									immediate_offset = 0;
-								}
-							}
-							else {
-								wrongOperand(insn, cheatMetadata, start_address);
-								return;
-							}
-						}
-					}
-					else {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;		
-					}
-					break;
-				}
-				case AD_INSTR_LDRSW: {
-					if (insn -> num_operands > 3 || insn -> operands[0].op_reg.rtbl[0][0] != 'x') {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;
-					}
-					machineState.X[insn -> operands[0].op_reg.rn] = 0;
-					int32_t temp_word = 0;
-					if (insn -> num_operands == 3) {
-						dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn] + (insn -> operands[2].op_imm.bits), (void*)&temp_word, sizeof(int32_t));
-					}
-					else {
-						dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn -> operands[1].op_reg.rn], (void*)&temp_word, sizeof(int32_t));
-					}
-					int64_t new_word = temp_word;
-					memcpy(&machineState.X[insn -> operands[0].op_reg.rn], &new_word, sizeof(int64_t));
-					break;
-				}
-				case AD_INSTR_MADD: {
-					if (insn -> num_operands != 4 || ((insn -> operands[0].op_reg.rtbl[0][0] | insn -> operands[1].op_reg.rtbl[0][0] | insn -> operands[2].op_reg.rtbl[0][0] | insn -> operands[3].op_reg.rtbl[0][0]) != insn -> operands[0].op_reg.rtbl[0][0])) {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;
-					}
-					machineState.X[insn -> operands[0].op_reg.rn] = (machineState.X[insn -> operands[1].op_reg.rn] * machineState.X[insn -> operands[2].op_reg.rn]) + machineState.X[insn -> operands[3].op_reg.rn];
-					break;
-				}				
-				case AD_INSTR_MOV: {
-					if (insn -> num_operands != 2) {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;
-					}
-					if (insn -> operands[1].type == AD_OP_REG) {
-						machineState.X[insn -> operands[0].op_reg.rn] = machineState.X[insn -> operands[1].op_reg.rn];
-					}
-					else if (insn -> operands[1].type == AD_OP_IMM) {
-						machineState.X[insn -> operands[0].op_reg.rn] = insn -> operands[1].op_imm.bits;
-					}
-					else {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;					
-					}
-					break;
-				}
-				case AD_INSTR_RET: {
-					start_address = returns.back();
-					returns.pop_back();
-					break;
-				}
-				case AD_INSTR_SMADDL: {
-					if (insn -> num_operands != 4 || insn -> operands[0].op_reg.rtbl[0][0] != 'x' || insn -> operands[1].op_reg.rtbl[0][0] != 'w' || insn -> operands[2].op_reg.rtbl[0][0] != 'w' || insn -> operands[3].op_reg.rtbl[0][0] != 'x') {
-						wrongOperand(insn, cheatMetadata, start_address);
-						return;
-					}
-					int32_t Wn = machineState.X[insn -> operands[1].op_reg.rn];
-					int32_t Wm = machineState.X[insn -> operands[2].op_reg.rn];
-					Wn *= Wm;
-					int64_t Xa = machineState.X[insn -> operands[3].op_reg.rn];
-					Xa += Wn;
-					machineState.X[insn -> operands[0].op_reg.rn] = Xa;
-					break;
-				}
-				case AD_INSTR_STP:
-				case AD_INSTR_STUR:
-				case AD_INSTR_STR: {
-					break;
-				}
-				case AD_INSTR_SUB: {
-					break;
-				}
-				default: {
-					wrongOperand(insn, cheatMetadata, start_address);
-					return;
-				}
-			}
-			start_address += 4;
-		}
-		char smallToPrint[64] = "";
-		if (unityDataStruct[i].get == false)
-			printf("%s: set = no register dump\n", unityDataStruct[i].output_name);
-		else {
-			printf("%s: Register %c0=", unityDataStruct[i].output_name, unityDataStruct[i].data_type);
-			switch(unityDataStruct[i].data_type) {
-				case 'w':
-					printf("%d\n", (uint32_t)machineState_copy.X[0]);
-					if (unityDataStruct[i].get)
-						snprintf(smallToPrint, sizeof(smallToPrint), "int32=%d", (uint32_t)machineState_copy.X[0]);
-					break;
-				case 'x':
-					printf("%ld\n", machineState_copy.X[0]);
-					if (unityDataStruct[i].get)
-						snprintf(smallToPrint, sizeof(smallToPrint), "int64=%ld", machineState_copy.X[0]);
-					break;
-				case 's':
-					printf("%f\n", machineState_copy.S[0]);
-					if (unityDataStruct[i].get)
-						snprintf(smallToPrint, sizeof(smallToPrint), "float=%f", machineState_copy.S[0]);
-					break;
-				case 'd':
-					printf("%f\n", machineState_copy.D[0]);
-					if (unityDataStruct[i].get)
-						snprintf(smallToPrint, sizeof(smallToPrint), "double=%f", machineState_copy.D[0]);
-					break;
-			}
-		}
-		if (insn)
-			ArmadilloDone(&insn);
-		std::string toReturn = "";
-		for (size_t x = 0; x < forPass.size(); x++) {
-			toReturn += forPass[x];
-			if (x+1 < forPass.size()) toReturn += "\n";
-		}
-		result.push_back({&unityDataStruct[i], toReturn, smallToPrint});
-		consoleUpdate(NULL);
-	}
-	uint64_t BID = 0;
-	char path[128] = "";
-	memcpy(&BID, &(cheatMetadata.main_nso_build_id), 8);
-	snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/%016lX.txt", cheatMetadata.title_id, __builtin_bswap64(BID));	
-	FILE* text_file = fopen(path, "w");
-	printf("Results: %ld\n", result.size());
-	if (!text_file) {
-		printf("Couldn't create txt file!\n");
-	}
-	else {
-		fwrite("{", 1, 1, text_file);
-		fwrite(unity_sdk.c_str(), unity_sdk.size(), 1, text_file);
-		fwrite("}", 1, 1, text_file);
-		fwrite("\n", 1, 1, text_file);
-		char address_temp[17] = "";
-		snprintf(address_temp, sizeof(address_temp), "0x%lx", cheatMetadata.main_nso_extents.base);
-		fwrite("{MAIN: ", 7, 1, text_file);
-		fwrite(address_temp, strlen(address_temp), 1, text_file);
-		fwrite("}", 1, 1, text_file);
-		fwrite("\n\n", 2, 1, text_file);		
-		for (size_t i = 0; i < result.size(); i++) {
-			if (result[i].data -> get) {
-				fwrite("{", 1, 1, text_file);
-				fwrite(result[i].register_print.c_str(), result[i].register_print.size(), 1, text_file);
-				fwrite("}\n", 2, 1, text_file);
-			}
-			fwrite("[", 1, 1, text_file);
-			fwrite(result[i].data -> search_name, strlen(result[i].data -> search_name), 1, text_file);
-			fwrite("]\n", 2, 1, text_file);
-			fwrite(result[i].toPrint.c_str(), result[i].toPrint.size(), 1, text_file);
-			fwrite("\n", 1, 1, text_file);
-			if (i+1 < result.size()) fwrite("\n", 1, 1 , text_file);
-		}
-		fclose(text_file);
-		printf("Dumped instructions to txt file:\n");
-		printf(path);	
-		printf("\n");
-	}
-	result.clear();
-	forPass.clear();
+void dumpPointers(const std::vector<std::string> UnityNames,
+                  const std::vector<uint32_t> UnityOffsets,
+                  const DmntCheatProcessMetadata cheatMetadata,
+                  std::string unity_sdk)
+{
+    ad_insn *insn = NULL;
+    MachineState machineState = {0};
+    std::vector<pointerDump> result;
+    std::vector<std::string> forPass;
+    for (size_t i = 0; i < unityDataStruct.size(); i++)
+    {
+        forPass.clear();
+        auto itr = std::find(UnityNames.begin(), UnityNames.end(), unityDataStruct[i].search_name);
+        if (itr == UnityNames.end())
+        {
+            Console::Printf("%s was not found!\n", unityDataStruct[i].search_name);
+            continue;
+        }
+        size_t index = itr - UnityNames.begin();
+        uint64_t start_address = cheatMetadata.main_nso_extents.base + UnityOffsets[index];
+        uint32_t instruction = 0;
+        std::vector<uint64_t> returns;
+        while (true)
+        {
+            dmntchtReadCheatProcessMemory(start_address, (void *)&instruction, sizeof(uint32_t));
+            if (returns.size() == 0 && instruction == 0xD65F03C0)
+                break;
+            if (insn)
+            {
+                ArmadilloDone(&insn);
+            }
+            int rc = ArmadilloDisassemble(instruction, start_address, &insn);
+            if (rc)
+            {
+                Console::Printf("Disassembler error! 0x%x/%d\n", rc, rc);
+                ArmadilloDone(&insn);
+                return;
+            }
+            else
+            {
+                forPass.push_back(insn->decoded);
+            }
+            uint8_t readSize = 0;
+            switch (insn->instr_id)
+            {
+                case AD_INSTR_ADD:
+                {
+                    if (insn->operands[2].type == AD_OP_REG)
+                    {
+                        machineState.X[insn->operands[0].op_reg.rn] =
+                            machineState.X[insn->operands[1].op_reg.rn] + machineState.X[insn->operands[2].op_reg.rn];
+                    }
+                    else if (insn->operands[2].type == AD_OP_IMM)
+                    {
+                        machineState.X[insn->operands[0].op_reg.rn] =
+                            machineState.X[insn->operands[1].op_reg.rn] + insn->operands[2].op_imm.bits;
+                    }
+                    else
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    break;
+                }
+                case AD_INSTR_ADRP:
+                {
+                    machineState.X[insn->operands[0].op_reg.rn] = insn->operands[1].op_imm.bits;
+                    break;
+                }
+                case AD_INSTR_B:
+                {
+                    start_address = insn->operands[0].op_imm.bits - 4;
+                    break;
+                }
+                case AD_INSTR_BL:
+                {
+                    if (insn->num_operands != 1)
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    returns.push_back(start_address);
+                    start_address = insn->operands[0].op_imm.bits - 4;
+                    break;
+                }
+                case AD_INSTR_BR:
+                {
+                    start_address = machineState.X[insn->operands[0].op_reg.rn] - 4;
+                    break;
+                }
+                case AD_INSTR_CMP:
+                {
+                    cmp_flag = machineState.X[insn->operands[0].op_reg.rn] == machineState.X[insn->operands[1].op_reg.rn];
+                    break;
+                }
+                case AD_INSTR_LDP:
+                {
+                    break;
+                }
+                case AD_INSTR_LDRB:
+                    readSize = 1;
+                case AD_INSTR_LDRH:
+                    if (!readSize)
+                        readSize = 2;
+                case AD_INSTR_LDR:
+                {
+                    if (insn->num_operands == 4)
+                    {
+                        if (insn->operands[0].op_reg.fp)
+                        {
+                            if ((insn->operands[3].type != AD_OP_IMM) || (insn->operands[3].op_imm.bits < 0))
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                            if (insn->operands[0].op_reg.rtbl[0][0] == 's')
+                            {
+                                dmntchtReadCheatProcessMemory(
+                                    (uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                        (machineState.X[insn->operands[2].op_reg.rn] << insn->operands[3].op_imm.bits),
+                                    (void *)&machineState.S[insn->operands[0].op_reg.rn],
+                                    sizeof(uint64_t));
+                            }
+                            else if (insn->operands[0].op_reg.rtbl[0][0] == 'd')
+                            {
+                                dmntchtReadCheatProcessMemory(
+                                    (uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                        (machineState.X[insn->operands[2].op_reg.rn] << insn->operands[3].op_imm.bits),
+                                    (void *)&machineState.D[insn->operands[0].op_reg.rn],
+                                    sizeof(uint64_t));
+                            }
+                            else
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            if ((insn->operands[3].type != AD_OP_IMM) || (insn->operands[3].op_imm.bits < 0))
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                            if (insn->operands[0].op_reg.rtbl[0][0] == 'w')
+                            {
+                                machineState.X[insn->operands[0].op_reg.rn] = 0;
+                                dmntchtReadCheatProcessMemory(
+                                    (uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                        (machineState.X[insn->operands[2].op_reg.rn] << insn->operands[3].op_imm.bits),
+                                    (void *)&machineState.X[insn->operands[0].op_reg.rn],
+                                    (readSize ? readSize : sizeof(uint32_t)));
+                            }
+                            else if (insn->operands[0].op_reg.rtbl[0][0] == 'x')
+                            {
+                                machineState.X[insn->operands[0].op_reg.rn] = 0;
+                                dmntchtReadCheatProcessMemory(
+                                    (uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                        (machineState.X[insn->operands[2].op_reg.rn] << insn->operands[3].op_imm.bits),
+                                    (void *)&machineState.X[insn->operands[0].op_reg.rn],
+                                    (readSize ? readSize : sizeof(uint64_t)));
+                            }
+                            else
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                        }
+                    }
+
+                    else if (insn->num_operands == 3)
+                    {
+                        if (insn->operands[0].op_reg.fp)
+                        {
+                            if (insn->operands[0].op_reg.rtbl[0][0] == 's')
+                            {
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                                                  (insn->operands[2].op_imm.bits),
+                                                              (void *)&machineState.S[insn->operands[0].op_reg.rn],
+                                                              sizeof(uint64_t));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = insn->operands[2].op_imm.bits;
+                                }
+                            }
+                            else if (insn->operands[0].op_reg.rtbl[0][0] == 'd')
+                            {
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                                                  (insn->operands[2].op_imm.bits),
+                                                              (void *)&machineState.D[insn->operands[0].op_reg.rn],
+                                                              sizeof(uint64_t));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = insn->operands[2].op_imm.bits;
+                                }
+                            }
+                            else
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            if (insn->operands[0].op_reg.rtbl[0][0] == 'w')
+                            {
+                                machineState.X[insn->operands[0].op_reg.rn] = 0;
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                                                  (insn->operands[2].op_imm.bits),
+                                                              (void *)&machineState.X[insn->operands[0].op_reg.rn],
+                                                              (readSize ? readSize : sizeof(uint32_t)));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = insn->operands[2].op_imm.bits;
+                                }
+                            }
+                            else if (insn->operands[0].op_reg.rtbl[0][0] == 'x')
+                            {
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn] +
+                                                                  (insn->operands[2].op_imm.bits),
+                                                              (void *)&machineState.X[insn->operands[0].op_reg.rn],
+                                                              (readSize ? readSize : sizeof(uint64_t)));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = insn->operands[2].op_imm.bits;
+                                }
+                            }
+                            else
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                        }
+                    }
+                    else if (insn->num_operands == 2)
+                    {
+                        if (insn->operands[0].op_reg.fp)
+                        {
+                            if (insn->operands[0].op_reg.rtbl[0][0] == 's')
+                            {
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn],
+                                                              (void *)&machineState.S[insn->operands[0].op_reg.rn],
+                                                              sizeof(uint64_t));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = 0;
+                                }
+                            }
+                            else if (insn->operands[0].op_reg.rtbl[0][0] == 'd')
+                            {
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn],
+                                                              (void *)&machineState.D[insn->operands[0].op_reg.rn],
+                                                              sizeof(uint64_t));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = 0;
+                                }
+                            }
+                            else
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            if (insn->operands[0].op_reg.rtbl[0][0] == 'w')
+                            {
+                                machineState.X[insn->operands[0].op_reg.rn] = 0;
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn],
+                                                              (void *)&machineState.X[insn->operands[0].op_reg.rn],
+                                                              (readSize ? readSize : sizeof(uint32_t)));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = 0;
+                                }
+                            }
+                            else if (insn->operands[0].op_reg.rtbl[0][0] == 'x')
+                            {
+                                dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn],
+                                                              (void *)&machineState.X[insn->operands[0].op_reg.rn],
+                                                              (readSize ? readSize : sizeof(uint64_t)));
+                                if (insn->operands[0].op_reg.rtbl[0][0] == unityDataStruct[i].data_type && insn->operands[0].op_reg.rn == 0)
+                                {
+                                    memcpy(&machineState_copy, &machineState, sizeof(machineState_copy));
+                                    registerPointer = insn->operands[1].op_reg.rn;
+                                    immediate_offset = 0;
+                                }
+                            }
+                            else
+                            {
+                                wrongOperand(insn, cheatMetadata, start_address);
+                                return;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    break;
+                }
+                case AD_INSTR_LDRSW:
+                {
+                    if (insn->num_operands > 3 || insn->operands[0].op_reg.rtbl[0][0] != 'x')
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    machineState.X[insn->operands[0].op_reg.rn] = 0;
+                    int32_t temp_word = 0;
+                    if (insn->num_operands == 3)
+                    {
+                        dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn] + (insn->operands[2].op_imm.bits),
+                                                      (void *)&temp_word,
+                                                      sizeof(int32_t));
+                    }
+                    else
+                    {
+                        dmntchtReadCheatProcessMemory((uint64_t)machineState.X[insn->operands[1].op_reg.rn],
+                                                      (void *)&temp_word,
+                                                      sizeof(int32_t));
+                    }
+                    int64_t new_word = temp_word;
+                    memcpy(&machineState.X[insn->operands[0].op_reg.rn], &new_word, sizeof(int64_t));
+                    break;
+                }
+                case AD_INSTR_MADD:
+                {
+                    if (insn->num_operands != 4 ||
+                        ((insn->operands[0].op_reg.rtbl[0][0] | insn->operands[1].op_reg.rtbl[0][0] | insn->operands[2].op_reg.rtbl[0][0] |
+                          insn->operands[3].op_reg.rtbl[0][0]) != insn->operands[0].op_reg.rtbl[0][0]))
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    machineState.X[insn->operands[0].op_reg.rn] =
+                        (machineState.X[insn->operands[1].op_reg.rn] * machineState.X[insn->operands[2].op_reg.rn]) +
+                        machineState.X[insn->operands[3].op_reg.rn];
+                    break;
+                }
+                case AD_INSTR_MOV:
+                {
+                    if (insn->num_operands != 2)
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    if (insn->operands[1].type == AD_OP_REG)
+                    {
+                        machineState.X[insn->operands[0].op_reg.rn] = machineState.X[insn->operands[1].op_reg.rn];
+                    }
+                    else if (insn->operands[1].type == AD_OP_IMM)
+                    {
+                        machineState.X[insn->operands[0].op_reg.rn] = insn->operands[1].op_imm.bits;
+                    }
+                    else
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    break;
+                }
+                case AD_INSTR_RET:
+                {
+                    start_address = returns.back();
+                    returns.pop_back();
+                    break;
+                }
+                case AD_INSTR_SMADDL:
+                {
+                    if (insn->num_operands != 4 || insn->operands[0].op_reg.rtbl[0][0] != 'x' || insn->operands[1].op_reg.rtbl[0][0] != 'w' ||
+                        insn->operands[2].op_reg.rtbl[0][0] != 'w' || insn->operands[3].op_reg.rtbl[0][0] != 'x')
+                    {
+                        wrongOperand(insn, cheatMetadata, start_address);
+                        return;
+                    }
+                    int32_t Wn = machineState.X[insn->operands[1].op_reg.rn];
+                    int32_t Wm = machineState.X[insn->operands[2].op_reg.rn];
+                    Wn *= Wm;
+                    int64_t Xa = machineState.X[insn->operands[3].op_reg.rn];
+                    Xa += Wn;
+                    machineState.X[insn->operands[0].op_reg.rn] = Xa;
+                    break;
+                }
+                case AD_INSTR_STP:
+                case AD_INSTR_STUR:
+                case AD_INSTR_STR:
+                {
+                    break;
+                }
+                case AD_INSTR_SUB:
+                {
+                    break;
+                }
+                default:
+                {
+                    wrongOperand(insn, cheatMetadata, start_address);
+                    return;
+                }
+            }
+            start_address += 4;
+        }
+        char smallToPrint[64] = "";
+        if (unityDataStruct[i].get == false)
+            Console::Printf("%s: set = no register dump\n", unityDataStruct[i].output_name);
+        else
+        {
+            Console::Printf("%s: Register %c0=", unityDataStruct[i].output_name, unityDataStruct[i].data_type);
+            switch (unityDataStruct[i].data_type)
+            {
+                case 'w':
+                    Console::Printf("%d\n", (uint32_t)machineState_copy.X[0]);
+                    if (unityDataStruct[i].get)
+                        snprintf(smallToPrint, sizeof(smallToPrint), "int32=%d", (uint32_t)machineState_copy.X[0]);
+                    break;
+                case 'x':
+                    Console::Printf("%ld\n", machineState_copy.X[0]);
+                    if (unityDataStruct[i].get)
+                        snprintf(smallToPrint, sizeof(smallToPrint), "int64=%ld", machineState_copy.X[0]);
+                    break;
+                case 's':
+                    Console::Printf("%f\n", machineState_copy.S[0]);
+                    if (unityDataStruct[i].get)
+                        snprintf(smallToPrint, sizeof(smallToPrint), "float=%f", machineState_copy.S[0]);
+                    break;
+                case 'd':
+                    Console::Printf("%f\n", machineState_copy.D[0]);
+                    if (unityDataStruct[i].get)
+                        snprintf(smallToPrint, sizeof(smallToPrint), "double=%f", machineState_copy.D[0]);
+                    break;
+            }
+        }
+        if (insn)
+            ArmadilloDone(&insn);
+        std::string toReturn = "";
+        for (size_t x = 0; x < forPass.size(); x++)
+        {
+            toReturn += forPass[x];
+            if (x + 1 < forPass.size())
+                toReturn += "\n";
+        }
+        result.push_back({&unityDataStruct[i], toReturn, smallToPrint});
+    }
+    uint64_t BID = 0;
+    char path[128] = "";
+    memcpy(&BID, &(cheatMetadata.main_nso_build_id), 8);
+    snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/%016lX.txt", cheatMetadata.title_id, __builtin_bswap64(BID));
+    FILE *text_file = fopen(path, "w");
+    Console::Printf("Results: %ld\n", result.size());
+    if (!text_file)
+    {
+        Console::Printf("Couldn't create txt file!\n");
+    }
+    else
+    {
+        fwrite("{", 1, 1, text_file);
+        fwrite(unity_sdk.c_str(), unity_sdk.size(), 1, text_file);
+        fwrite("}", 1, 1, text_file);
+        fwrite("\n", 1, 1, text_file);
+        char address_temp[17] = "";
+        snprintf(address_temp, sizeof(address_temp), "0x%lx", cheatMetadata.main_nso_extents.base);
+        fwrite("{MAIN: ", 7, 1, text_file);
+        fwrite(address_temp, strlen(address_temp), 1, text_file);
+        fwrite("}", 1, 1, text_file);
+        fwrite("\n\n", 2, 1, text_file);
+        for (size_t i = 0; i < result.size(); i++)
+        {
+            if (result[i].data->get)
+            {
+                fwrite("{", 1, 1, text_file);
+                fwrite(result[i].register_print.c_str(), result[i].register_print.size(), 1, text_file);
+                fwrite("}\n", 2, 1, text_file);
+            }
+            fwrite("[", 1, 1, text_file);
+            fwrite(result[i].data->search_name, strlen(result[i].data->search_name), 1, text_file);
+            fwrite("]\n", 2, 1, text_file);
+            fwrite(result[i].toPrint.c_str(), result[i].toPrint.size(), 1, text_file);
+            fwrite("\n", 1, 1, text_file);
+            if (i + 1 < result.size())
+                fwrite("\n", 1, 1, text_file);
+        }
+        fclose(text_file);
+        Console::Printf("Dumped instructions to txt file:\n");
+        Console::Printf(path);
+        Console::Printf("\n");
+    }
+    result.clear();
+    forPass.clear();
 }

--- a/source/asmInterpreter.cpp
+++ b/source/asmInterpreter.cpp
@@ -2,7 +2,7 @@
 #include "Console.hpp"
 #include "UnityDumps.hpp"
 
-void wrongOperand(ad_insn *insn, const DmntCheatProcessMetadata cheatMetadata, uint64_t address)
+void wrongOperand(ad_insn *insn, const DmntCheatProcessMetadata &cheatMetadata, uint64_t address)
 {
     Console::Printf("Unsupported instruction! %s\n", insn->decoded);
     Console::Printf("offset: 0x%lx\n", address - cheatMetadata.main_nso_extents.base);

--- a/source/dmntcht.c
+++ b/source/dmntcht.c
@@ -14,183 +14,225 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #define NX_SERVICE_ASSUME_NON_DOMAIN
-#include "service_guard.h"
 #include "dmntcht.h"
+#include "service_guard.h"
 
 static Service g_dmntchtSrv;
 
 NX_GENERATE_SERVICE_GUARD(dmntcht);
 
-Result _dmntchtInitialize(void) {
+Result _dmntchtInitialize(void)
+{
     return smGetService(&g_dmntchtSrv, "dmnt:cht");
 }
 
-void _dmntchtCleanup(void) {
+void _dmntchtCleanup(void)
+{
     serviceClose(&g_dmntchtSrv);
 }
 
-Service* dmntchtGetServiceSession(void) {
+Service *dmntchtGetServiceSession(void)
+{
     return &g_dmntchtSrv;
 }
 
-Result dmntchtHasCheatProcess(bool *out) {
+Result dmntchtHasCheatProcess(bool *out)
+{
     u8 tmp;
     Result rc = serviceDispatchOut(&g_dmntchtSrv, 65000, tmp);
-    if (R_SUCCEEDED(rc) && out) *out = tmp & 1;
+    if (R_SUCCEEDED(rc) && out)
+        *out = tmp & 1;
     return rc;
 }
 
-Result dmntchtGetCheatProcessEvent(Event *event) {
+Result dmntchtGetCheatProcessEvent(Event *event)
+{
     Handle evt_handle;
-    Result rc = serviceDispatch(&g_dmntchtSrv, 65001,
-        .out_handle_attrs = { SfOutHandleAttr_HipcCopy },
-        .out_handles = &evt_handle,
-    );
+    Result rc = serviceDispatch(&g_dmntchtSrv, 65001, .out_handle_attrs = {SfOutHandleAttr_HipcCopy}, .out_handles = &evt_handle, );
 
-    if (R_SUCCEEDED(rc)) {
+    if (R_SUCCEEDED(rc))
+    {
         eventLoadRemote(event, evt_handle, true);
     }
 
     return rc;
 }
 
-Result dmntchtGetCheatProcessMetadata(DmntCheatProcessMetadata *out_metadata) {
+Result dmntchtGetCheatProcessMetadata(DmntCheatProcessMetadata *out_metadata)
+{
     return serviceDispatchOut(&g_dmntchtSrv, 65002, *out_metadata);
 }
 
-static Result _dmntchtCmdVoid(Service* srv, u32 cmd_id) {
+static Result _dmntchtCmdVoid(Service *srv, u32 cmd_id)
+{
     return serviceDispatch(srv, cmd_id);
 }
 
-Result dmntchtForceOpenCheatProcess(void) {
+Result dmntchtForceOpenCheatProcess(void)
+{
     return _dmntchtCmdVoid(&g_dmntchtSrv, 65003);
 }
 
-Result dmntchtPauseCheatProcess(void) {
+Result dmntchtPauseCheatProcess(void)
+{
     return _dmntchtCmdVoid(&g_dmntchtSrv, 65004);
 }
 
-Result dmntchtResumeCheatProcess(void) {
+Result dmntchtResumeCheatProcess(void)
+{
     return _dmntchtCmdVoid(&g_dmntchtSrv, 65005);
 }
 
-static Result _dmntchtGetCount(u64 *out_count, u32 cmd_id) {
+static Result _dmntchtGetCount(u64 *out_count, u32 cmd_id)
+{
     return serviceDispatchOut(&g_dmntchtSrv, cmd_id, *out_count);
 }
 
-static Result _dmntchtGetEntries(void *buffer, u64 buffer_size, u64 offset, u64 *out_count, u32 cmd_id) {
-    return serviceDispatchInOut(&g_dmntchtSrv, cmd_id, offset, *out_count,
-        .buffer_attrs = { SfBufferAttr_Out | SfBufferAttr_HipcMapAlias },
-        .buffers = { { buffer, buffer_size } },
-    );
+static Result _dmntchtGetEntries(void *buffer, u64 buffer_size, u64 offset, u64 *out_count, u32 cmd_id)
+{
+    return serviceDispatchInOut(&g_dmntchtSrv,
+                                cmd_id,
+                                offset,
+                                *out_count,
+                                .buffer_attrs = {SfBufferAttr_Out | SfBufferAttr_HipcMapAlias},
+                                .buffers = {{buffer, buffer_size}}, );
 }
 
-static Result _dmntchtCmdInU32NoOut(u32 in, u32 cmd_id) {
+static Result _dmntchtCmdInU32NoOut(u32 in, u32 cmd_id)
+{
     return serviceDispatchIn(&g_dmntchtSrv, cmd_id, in);
 }
 
-Result dmntchtGetCheatProcessMappingCount(u64 *out_count) {
+Result dmntchtGetCheatProcessMappingCount(u64 *out_count)
+{
     return _dmntchtGetCount(out_count, 65100);
 }
 
-Result dmntchtGetCheatProcessMappings(MemoryInfo *buffer, u64 max_count, u64 offset, u64 *out_count) {
+Result dmntchtGetCheatProcessMappings(MemoryInfo *buffer, u64 max_count, u64 offset, u64 *out_count)
+{
     return _dmntchtGetEntries(buffer, sizeof(*buffer) * max_count, offset, out_count, 65101);
 }
 
-Result dmntchtReadCheatProcessMemory(u64 address, void *buffer, size_t size) {
-    const struct {
-        u64 address;
-        u64 size;
-    } in = { address, size };
-    return serviceDispatchIn(&g_dmntchtSrv, 65102, in,
-        .buffer_attrs = { SfBufferAttr_Out | SfBufferAttr_HipcMapAlias },
-        .buffers = { { buffer, size } },
-    );
+Result dmntchtReadCheatProcessMemory(u64 address, void *buffer, size_t size)
+{
+    const struct
+    {
+            u64 address;
+            u64 size;
+    } in = {address, size};
+    return serviceDispatchIn(&g_dmntchtSrv,
+                             65102,
+                             in,
+                             .buffer_attrs = {SfBufferAttr_Out | SfBufferAttr_HipcMapAlias},
+                             .buffers = {{buffer, size}}, );
 }
 
-Result dmntchtWriteCheatProcessMemory(u64 address, const void *buffer, size_t size) {
-    const struct {
-        u64 address;
-        u64 size;
-    } in = { address, size };
-    return serviceDispatchIn(&g_dmntchtSrv, 65103, in,
-        .buffer_attrs = { SfBufferAttr_In | SfBufferAttr_HipcMapAlias },
-        .buffers = { { buffer, size } },
-    );
+Result dmntchtWriteCheatProcessMemory(u64 address, const void *buffer, size_t size)
+{
+    const struct
+    {
+            u64 address;
+            u64 size;
+    } in = {address, size};
+    return serviceDispatchIn(&g_dmntchtSrv,
+                             65103,
+                             in,
+                             .buffer_attrs = {SfBufferAttr_In | SfBufferAttr_HipcMapAlias},
+                             .buffers = {{buffer, size}}, );
 }
 
-Result dmntchtQueryCheatProcessMemory(MemoryInfo *mem_info, u64 address){
+Result dmntchtQueryCheatProcessMemory(MemoryInfo *mem_info, u64 address)
+{
     return serviceDispatchInOut(&g_dmntchtSrv, 65104, address, *mem_info);
 }
 
-Result dmntchtGetCheatCount(u64 *out_count) {
+Result dmntchtGetCheatCount(u64 *out_count)
+{
     return _dmntchtGetCount(out_count, 65200);
 }
 
-Result dmntchtGetCheats(DmntCheatEntry *buffer, u64 max_count, u64 offset, u64 *out_count) {
+Result dmntchtGetCheats(DmntCheatEntry *buffer, u64 max_count, u64 offset, u64 *out_count)
+{
     return _dmntchtGetEntries(buffer, sizeof(*buffer) * max_count, offset, out_count, 65201);
 }
 
-Result dmntchtGetCheatById(DmntCheatEntry *out, u32 cheat_id) {
-    return serviceDispatchIn(&g_dmntchtSrv, 65202, cheat_id,
-        .buffer_attrs = { SfBufferAttr_Out | SfBufferAttr_HipcMapAlias | SfBufferAttr_FixedSize },
-        .buffers = { { out, sizeof(*out) } },
-    );
+Result dmntchtGetCheatById(DmntCheatEntry *out, u32 cheat_id)
+{
+    return serviceDispatchIn(&g_dmntchtSrv,
+                             65202,
+                             cheat_id,
+                             .buffer_attrs = {SfBufferAttr_Out | SfBufferAttr_HipcMapAlias | SfBufferAttr_FixedSize},
+                             .buffers = {{out, sizeof(*out)}}, );
 }
 
-Result dmntchtToggleCheat(u32 cheat_id) {
+Result dmntchtToggleCheat(u32 cheat_id)
+{
     return _dmntchtCmdInU32NoOut(cheat_id, 65203);
 }
 
-Result dmntchtAddCheat(DmntCheatDefinition *cheat_def, bool enabled, u32 *out_cheat_id) {
+Result dmntchtAddCheat(DmntCheatDefinition *cheat_def, bool enabled, u32 *out_cheat_id)
+{
     const u8 in = enabled != 0;
-    return serviceDispatchInOut(&g_dmntchtSrv, 65204, in, *out_cheat_id,
-        .buffer_attrs = { SfBufferAttr_In | SfBufferAttr_HipcMapAlias | SfBufferAttr_FixedSize },
-        .buffers = { { cheat_def, sizeof(*cheat_def) } },
-    );
+    return serviceDispatchInOut(&g_dmntchtSrv,
+                                65204,
+                                in,
+                                *out_cheat_id,
+                                .buffer_attrs = {SfBufferAttr_In | SfBufferAttr_HipcMapAlias | SfBufferAttr_FixedSize},
+                                .buffers = {{cheat_def, sizeof(*cheat_def)}}, );
 }
 
-Result dmntchtRemoveCheat(u32 cheat_id) {
+Result dmntchtRemoveCheat(u32 cheat_id)
+{
     return _dmntchtCmdInU32NoOut(cheat_id, 65205);
 }
 
-Result dmntchtReadStaticRegister(u64 *out, u8 which) {
+Result dmntchtReadStaticRegister(u64 *out, u8 which)
+{
     return serviceDispatchInOut(&g_dmntchtSrv, 65206, which, *out);
 }
 
-Result dmntchtWriteStaticRegister(u8 which, u64 value) {
-    const struct {
-        u64 which;
-        u64 value;
-    } in = { which, value };
+Result dmntchtWriteStaticRegister(u8 which, u64 value)
+{
+    const struct
+    {
+            u64 which;
+            u64 value;
+    } in = {which, value};
 
     return serviceDispatchIn(&g_dmntchtSrv, 65207, in);
 }
 
-Result dmntchtResetStaticRegisters() {
+Result dmntchtResetStaticRegisters()
+{
     return _dmntchtCmdVoid(&g_dmntchtSrv, 65208);
 }
 
-Result dmntchtGetFrozenAddressCount(u64 *out_count) {
+Result dmntchtGetFrozenAddressCount(u64 *out_count)
+{
     return _dmntchtGetCount(out_count, 65300);
 }
 
-Result dmntchtGetFrozenAddresses(DmntFrozenAddressEntry *buffer, u64 max_count, u64 offset, u64 *out_count) {
+Result dmntchtGetFrozenAddresses(DmntFrozenAddressEntry *buffer, u64 max_count, u64 offset, u64 *out_count)
+{
     return _dmntchtGetEntries(buffer, sizeof(*buffer) * max_count, offset, out_count, 65301);
 }
 
-Result dmntchtGetFrozenAddress(DmntFrozenAddressEntry *out, u64 address) {
+Result dmntchtGetFrozenAddress(DmntFrozenAddressEntry *out, u64 address)
+{
     return serviceDispatchInOut(&g_dmntchtSrv, 65302, address, *out);
 }
 
-Result dmntchtEnableFrozenAddress(u64 address, u64 width, u64 *out_value) {
-    const struct {
-        u64 address;
-        u64 width;
-    } in = { address, width };
+Result dmntchtEnableFrozenAddress(u64 address, u64 width, u64 *out_value)
+{
+    const struct
+    {
+            u64 address;
+            u64 width;
+    } in = {address, width};
     return serviceDispatchInOut(&g_dmntchtSrv, 65303, in, *out_value);
 }
 
-Result dmntchtDisableFrozenAddress(u64 address) {
+Result dmntchtDisableFrozenAddress(u64 address)
+{
     return serviceDispatchIn(&g_dmntchtSrv, 65304, address);
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -411,9 +411,11 @@ void dumpAsLog()
         fwrite(temp, strlen(temp), 1, text_file);
     }
     fclose(text_file);
-    Console::Printf("Dumped log file to:\n");
-    Console::Printf(path);
-    Console::Printf("\n");
+    // lol who uses printf like this?
+    // printf("Dumped log file to:\n", path);
+    // printf(path);
+    // printf("\n");
+    Console::Printf("Dumped log file to:\n%s\n", path);
 }
 
 // Main program entrypoint
@@ -540,7 +542,7 @@ int main(int argc, char *argv[])
                                 "\uE0EF to Exit\n\n");
             }
             else
-                Console::Printf("\n----------\nPress \uE0E0 to Start\nPress \uE0EF to Exit\n\n");
+                Console::Printf("\n^----------^\nPress \uE0E0 to Start\nPress \uE0EF to Exit\n\n");
             bool overwrite = true;
             while (appletMainLoop())
             {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -554,7 +554,9 @@ int main(int argc, char *argv[])
                 if (kDown & HidNpadButton_Plus)
                 {
                     dmntchtExit();
-                    consoleExit(NULL);
+                    // I really don't like this but there's no other way.
+                    SDL::Text::Exit();
+                    SDL::Exit();
                     return 0;
                 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -85,7 +85,7 @@ bool checkIfUnity()
             char *result = searchString(buffer_c, (char *)test_4, memoryInfoBuffers[i].size);
             if (result)
             {
-                Console::Printf("%s\n", result);
+                Console::Printf("^%s^\n", result);
                 unity_sdk = result;
                 delete[] buffer_c;
                 return true;
@@ -357,13 +357,13 @@ void searchFunctionsUnity()
             if (string.length() > 0)
             {
                 UnityNames.push_back(string);
-                Console::Printf("#%ld: %s\n", UnityNames.size(), UnityNames.back().c_str());
+                Console::Printf("*#*^%ld^: %s\n", UnityNames.size(), UnityNames.back().c_str());
             }
         }
         else
             break;
     }
-    Console::Printf("Found %ld Unity functions.\n", UnityNames.size());
+    Console::Printf("Found *%ld* Unity functions.\n", UnityNames.size());
     uint64_t second_array = (u64)array_start + ((i - 1) * 8);
     for (size_t x = 0; x < UnityNames.size(); x++)
     {
@@ -415,7 +415,7 @@ void dumpAsLog()
     // printf("Dumped log file to:\n", path);
     // printf(path);
     // printf("\n");
-    Console::Printf("Dumped log file to: %s\n", path);
+    Console::Printf("Dumped log file to: *%s*\n", path);
 }
 
 // Main program entrypoint
@@ -442,6 +442,8 @@ int main(int argc, char *argv[])
     // This will add whatever character is passed as a special character to change the text color. I saw this thing prints something in blue at some point?
     // SDLLib uses unions for colors instead of a struct. They must be assigned and passed like this: {0xRRGGBBAA}
     SDL::Text::AddColorCharacter(L'^', {0x00FFFFFF});
+    SDL::Text::AddColorCharacter(L'*', {0x00FF00FF});
+    SDL::Text::AddColorCharacter(L'>', {0xFF0000FF});
 
     // You can use this to set the Console's font size to whatever you want. The default text size in pixels is 20.
     // Console::SetFontSize(20);
@@ -458,14 +460,14 @@ int main(int argc, char *argv[])
     bool error = false;
     if (!isServiceRunning("dmnt:cht"))
     {
-        Console::Printf("DMNT:CHT not detected!\n");
+        Console::Printf(">DMNT:CHT not detected!>\n");
         error = true;
     }
     pmdmntInitialize();
     uint64_t PID = 0;
     if (R_FAILED(pmdmntGetApplicationProcessId(&PID)))
     {
-        Console::Printf("Game not initialized.\n");
+        Console::Printf(">Game not initialized.>\n");
         error = true;
     }
     pmdmntExit();
@@ -493,7 +495,7 @@ int main(int argc, char *argv[])
     {
         pmdmntExit();
         size_t availableHeap = checkAvailableHeap();
-        Console::Printf("Available Heap: %ld MB\n", (availableHeap / (1024 * 1024)));
+        Console::Printf("Available Heap: *%ld* MB\n", (availableHeap / (1024 * 1024)));
         dmntchtInitialize();
         bool hasCheatProcess = false;
         dmntchtHasCheatProcess(&hasCheatProcess);
@@ -504,25 +506,24 @@ int main(int argc, char *argv[])
 
         Result res = dmntchtGetCheatProcessMetadata(&cheatMetadata);
         if (res)
-            Console::Printf("dmntchtGetCheatProcessMetadata ret: 0x%x\n", res);
+            Console::Printf(">dmntchtGetCheatProcessMetadata ret: 0x%x>\n", res);
 
         res = dmntchtGetCheatProcessMappingCount(&mappings_count);
         if (res)
-            Console::Printf("dmntchtGetCheatProcessMappingCount ret: 0x%x\n", res);
+            Console::Printf(">dmntchtGetCheatProcessMappingCount ret: 0x%x>\n", res);
         else
-            Console::Printf("Mapping count: %ld\n", mappings_count);
+            Console::Printf("Mapping count: *%ld*\n", mappings_count);
 
         memoryInfoBuffers = new MemoryInfo[mappings_count];
 
         res = dmntchtGetCheatProcessMappings(memoryInfoBuffers, mappings_count, 0, &mappings_count);
         if (res)
-            Console::Printf("DmntchtGetCheatProcessMappings返回: 0x%x\n", res);
+            Console::Printf(">DmntchtGetCheatProcessMappings返回: 0x%x>\n", res);
 
         //Test run
 
         if (checkIfUnity())
         {
-
             uint64_t BID = 0;
             memcpy(&BID, &(cheatMetadata.main_nso_build_id), 8);
             mkdir("sdmc:/switch/UnityFuncDumper/", 777);
@@ -604,7 +605,7 @@ int main(int argc, char *argv[])
             dumpPointers(UnityNames, UnityOffsets, cheatMetadata, unity_sdk);
         }
         dmntchtExit();
-        Console::Printf("Press \uE0EF to exit.");
+        Console::Printf("Press \uE0EF to exit.\n");
         while (appletMainLoop())
         {
             // Scan the gamepad. This should be done once for each frame
@@ -624,7 +625,7 @@ int main(int argc, char *argv[])
     }
 
     // Deinitialize and clean up resources used by the console (important!)
-    // There's no need to clear vectors like this. It's going to happen any way when they go out of scope or the program ends.
+    // There's no need to clear vectors like this. It's going to happen anyway when they go out of scope or the program ends.
     // UnityNames.clear();
     // UnityOffsets.clear();
     SDL::Text::Exit();

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -594,7 +594,9 @@ int main(int argc, char *argv[])
                 Console::Printf("Searching RAM...\n\n");
                 appletSetCpuBoostMode(ApmCpuBoostMode_FastLoad);
                 searchFunctionsUnity();
-                Console::Printf("\n^---------------------------------------------^\n\nSearch finished!\n");
+                Console::Printf("\n^---------------------------------------------^\n\n");
+                Console::Reset();
+                Console::Printf("Search finished!\n");
                 dumpAsLog();
                 appletSetCpuBoostMode(ApmCpuBoostMode_Normal);
                 delete[] memoryInfoBuffers;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -441,9 +441,9 @@ int main(int argc, char *argv[])
 
     // This will add whatever character is passed as a special character to change the text color. I saw this thing prints something in blue at some point?
     // SDLLib uses unions for colors instead of a struct. They must be assigned and passed like this: {0xRRGGBBAA}
-    SDL::Text::AddColorCharacter(L'^', {0x00FFFFFF});
-    SDL::Text::AddColorCharacter(L'*', {0x00FF00FF});
-    SDL::Text::AddColorCharacter(L'>', {0xFF0000FF});
+    SDL::Text::AddColorCharacter(L'^', {0x00FFFFFF}); // This makes text between two ^'s is a bright blue-green
+    SDL::Text::AddColorCharacter(L'*', {0x00FF00FF}); // This makes text between two *'s green.
+    SDL::Text::AddColorCharacter(L'>', {0xFF0000FF}); // This makes text between two >'s red.
 
     // You can use this to set the Console's font size to whatever you want. The default text size in pixels is 20.
     // Console::SetFontSize(20);

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -94,7 +94,7 @@ bool checkIfUnity()
         }
         i++;
     }
-    Console::Printf("这个游戏没有使用Unity引擎!\n");
+    Console::Printf(">这个游戏没有使用Unity引擎!>\n");
     return false;
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -415,7 +415,7 @@ void dumpAsLog()
     // printf("Dumped log file to:\n", path);
     // printf(path);
     // printf("\n");
-    Console::Printf("Dumped log file to:\n%s\n", path);
+    Console::Printf("Dumped log file to: %s\n", path);
 }
 
 // Main program entrypoint
@@ -471,7 +471,7 @@ int main(int argc, char *argv[])
     pmdmntExit();
     if (error)
     {
-        Console::Printf("Press + to exit.");
+        Console::Printf("Press + to exit.\n");
         while (appletMainLoop())
         {
             // Scan the gamepad. This should be done once for each frame

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -3,541 +3,625 @@
 #include <stdlib.h>
 
 // Include the main libnx system header, for Switch development
+#include "Console.hpp"
+#include "Logger.hpp"
+#include "SDL.hpp"
+#include "asmInterpreter.hpp"
 #include <switch.h>
 #include <sys/stat.h>
-#include "asmInterpreter.hpp"
 
 DmntCheatProcessMetadata cheatMetadata = {0};
 u64 mappings_count = 0;
-MemoryInfo* memoryInfoBuffers = 0;
+MemoryInfo *memoryInfoBuffers = 0;
 
-bool isServiceRunning(const char *serviceName) {	
-	Handle handle;	
-	SmServiceName service_name = smEncodeName(serviceName);	
-	if (R_FAILED(smRegisterService(&handle, service_name, false, 1))) 
-		return true;
-	else {
-		svcCloseHandle(handle);	
-		smUnregisterService(service_name);
-		return false;
-	}
+bool isServiceRunning(const char *serviceName)
+{
+    Handle handle;
+    SmServiceName service_name = smEncodeName(serviceName);
+    if (R_FAILED(smRegisterService(&handle, service_name, false, 1)))
+        return true;
+    else
+    {
+        svcCloseHandle(handle);
+        smUnregisterService(service_name);
+        return false;
+    }
 }
 
-template <typename T> T searchString(char* buffer, T string, u64 buffer_size, bool null_terminated = false, bool whole = false) {
-	char* buffer_end = &buffer[buffer_size];
-	size_t string_len = (std::char_traits<std::remove_pointer_t<std::remove_reference_t<T>>>::length(string) + (null_terminated ? 1 : 0)) * sizeof(std::remove_pointer_t<std::remove_reference_t<T>>);
-	T string_end = &string[std::char_traits<std::remove_pointer_t<std::remove_reference_t<T>>>::length(string) + (null_terminated ? 1 : 0)];
-	char* result = std::search(buffer, buffer_end, (char*)string, (char*)string_end);
-	if (whole) {
-		while ((uint64_t)result != (uint64_t)&buffer[buffer_size]) {
-			if (!result[-1 * sizeof(std::remove_pointer_t<std::remove_reference_t<T>>)])
-				return (T)result;
-			result = std::search(result + string_len, buffer_end, (char*)string, (char*)string_end);
-		}
-	}
-	else if ((uint64_t)result != (uint64_t)&buffer[buffer_size]) {
-		return (T)result;
-	}
-	return nullptr;
+template <typename T>
+T searchString(char *buffer, T string, u64 buffer_size, bool null_terminated = false, bool whole = false)
+{
+    char *buffer_end = &buffer[buffer_size];
+    size_t string_len = (std::char_traits<std::remove_pointer_t<std::remove_reference_t<T>>>::length(string) + (null_terminated ? 1 : 0)) *
+                        sizeof(std::remove_pointer_t<std::remove_reference_t<T>>);
+    T string_end = &string[std::char_traits<std::remove_pointer_t<std::remove_reference_t<T>>>::length(string) + (null_terminated ? 1 : 0)];
+    char *result = std::search(buffer, buffer_end, (char *)string, (char *)string_end);
+    if (whole)
+    {
+        while ((uint64_t)result != (uint64_t)&buffer[buffer_size])
+        {
+            if (!result[-1 * sizeof(std::remove_pointer_t<std::remove_reference_t<T>>)])
+                return (T)result;
+            result = std::search(result + string_len, buffer_end, (char *)string, (char *)string_end);
+        }
+    }
+    else if ((uint64_t)result != (uint64_t)&buffer[buffer_size])
+    {
+        return (T)result;
+    }
+    return nullptr;
 }
 
 std::string unity_sdk = "";
 
-size_t checkAvailableHeap() {
-	size_t startSize = 200 * 1024 * 1024;
-	void* allocation = malloc(startSize);
-	while (allocation) {
-		free(allocation);
-		startSize += 1024 * 1024;
-		allocation = malloc(startSize);
-	}
-	return startSize - (1024 * 1024);
+size_t checkAvailableHeap()
+{
+    size_t startSize = 200 * 1024 * 1024;
+    void *allocation = malloc(startSize);
+    while (allocation)
+    {
+        free(allocation);
+        startSize += 1024 * 1024;
+        allocation = malloc(startSize);
+    }
+    return startSize - (1024 * 1024);
 }
 
-bool checkIfUnity() {
-	size_t i = 0;
-	while (i < mappings_count) {
-		if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx && memoryInfoBuffers[i].type == MemType_CodeStatic) {
-			if (memoryInfoBuffers[i].size > 200'000'000) {
-				continue;
-			}
-			char test_4[] = "SDK MW+UnityTechnologies+Unity";
-			char* buffer_c = new char[memoryInfoBuffers[i].size];
-			dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void*)buffer_c, memoryInfoBuffers[i].size);
-			char* result = searchString(buffer_c, (char*)test_4, memoryInfoBuffers[i].size);
-			if (result) {
-				printf("%s\n", result);
-				unity_sdk = result;
-				delete[] buffer_c;
-				return true;
-			}
-			delete[] buffer_c;
-		}
-		i++;
-	}
-	printf("This game is not using Unity!\n");
-	return false;
+bool checkIfUnity()
+{
+    size_t i = 0;
+    while (i < mappings_count)
+    {
+        if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx &&
+            memoryInfoBuffers[i].type == MemType_CodeStatic)
+        {
+            if (memoryInfoBuffers[i].size > 200'000'000)
+            {
+                continue;
+            }
+            char test_4[] = "SDK MW+UnityTechnologies+Unity";
+            char *buffer_c = new char[memoryInfoBuffers[i].size];
+            dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void *)buffer_c, memoryInfoBuffers[i].size);
+            char *result = searchString(buffer_c, (char *)test_4, memoryInfoBuffers[i].size);
+            if (result)
+            {
+                Console::Printf("%s\n", result);
+                unity_sdk = result;
+                delete[] buffer_c;
+                return true;
+            }
+            delete[] buffer_c;
+        }
+        i++;
+    }
+    Console::Printf("这个游戏没有使用Unity引擎!\n");
+    return false;
 }
 
-char* findStringInBuffer(char* buffer_c, size_t buffer_size, const char* description) {
-	char* result = 0;
-	result = (char*)searchString(buffer_c, (char*)description, buffer_size);
-	return result;
+char *findStringInBuffer(char *buffer_c, size_t buffer_size, const char *description)
+{
+    char *result = 0;
+    result = (char *)searchString(buffer_c, (char *)description, buffer_size);
+    return result;
 }
 
 std::vector<std::string> UnityNames;
 std::vector<uint32_t> UnityOffsets;
 
-void searchFunctionsUnity2() {
-	size_t i = 0;
-	const char first_entry[] = "UnityEngineInternal.GIDebugVisualisation::ResetRuntimeInputTextures";
-	const char second_entry[] = "UnityEngineInternal.GIDebugVisualisation::PlayCycleMode";
-	const char* first_result = 0;
-	const char* second_result = 0;
-	printf("Base address: 0x%lx\n", cheatMetadata.main_nso_extents.base);
-	printf("Mapping %ld / %ld\r", i+1, mappings_count);	
-	consoleUpdate(NULL);
-	while (i < mappings_count) {
-		if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx && (memoryInfoBuffers[i].type == MemType_CodeStatic || memoryInfoBuffers[i].type == MemType_CodeReadOnly)) {
-			printf("Mapping %ld / %ld\r", i+1, mappings_count);
-			consoleUpdate(NULL);
-			if (memoryInfoBuffers[i].size > 200'000'000) {
-				i++;
-				continue;
-			}
-			char* buffer_c = new char[memoryInfoBuffers[i].size];
-			dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void*)buffer_c, memoryInfoBuffers[i].size);
-			char* result = 0;
-			result = findStringInBuffer(buffer_c, memoryInfoBuffers[i].size, first_entry);
-			if (result) {
-				first_result = (char*)(memoryInfoBuffers[i].addr + (result - buffer_c));
-				printf("Found 1. reference string at address 0x%lx\n", (uint64_t)first_result);
-				consoleUpdate(NULL);
-				result = findStringInBuffer(buffer_c, memoryInfoBuffers[i].size, second_entry);
-				if (result) {
-					second_result = (char*)(memoryInfoBuffers[i].addr + (result - buffer_c));
-					printf("Found 2. reference string at address 0x%lx\n", (uint64_t)second_result);
-					consoleUpdate(NULL);
-					delete[] buffer_c;
-					break;
-				}
-			}
-			delete[] buffer_c;
-		}
-		i++;
-	}
-	if (!first_result || !second_result) {
-		printf("Reference strings were not found! Aborting...\n");
-		consoleUpdate(NULL);
-		return;
-	}
-	printf("Mapping %ld / %ld\r", i+1, mappings_count);
-	consoleUpdate(NULL);
-	while (i < mappings_count) {
-		if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx && (memoryInfoBuffers[i].type == MemType_CodeStatic || memoryInfoBuffers[i].type == MemType_CodeReadOnly)) {
-			printf("Mapping %ld / %ld\r", i+1, mappings_count);
-			consoleUpdate(NULL);
-			if (memoryInfoBuffers[i].size > 200'000'000) {
-				i++;
-				continue;
-			}
-			int32_t* buffer = new int32_t[memoryInfoBuffers[i].size / sizeof(int32_t)];
-			printf("Buffer: 0x%lx, size: 0x%lx\n", (uint64_t)buffer, memoryInfoBuffers[i].size);
-			consoleUpdate(NULL);
-			dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void*)buffer, memoryInfoBuffers[i].size);
-			int32_t* result = 0;
-			for (size_t x = 0; x+1 < memoryInfoBuffers[i].size / sizeof(uint32_t); x++) {
-				int32_t diff1 = (int64_t)first_result - (memoryInfoBuffers[i].addr + (x * sizeof(uint32_t)));
-				int32_t diff2 = (int64_t)second_result - (memoryInfoBuffers[i].addr + (x * sizeof(uint32_t)));
-				if (buffer[x] == diff1 && buffer[x+1] == diff2) {
-					result = &buffer[x];
-					break;
-				}
-			}
-			if (!result) {
-				delete[] buffer;
-				i++;
-				continue;
-			}
-			printf("Found string array at buffer address: 0x%lx\n", (uint64_t)result);
-			consoleUpdate(NULL);
-			size_t x = 0;
-			while(true) {
-				int32_t offset = result[x];
-				char* address = (char*)((uint64_t)result + offset);
-				if (((uint64_t)address > (uint64_t)buffer + memoryInfoBuffers[i].size) || ((uint64_t)address < (uint64_t)buffer)) {
-					break;
-				}
-				if (!strncmp(address, "Unity", 5)) {
-					std::string name = address;
-					UnityNames.push_back(name);
-					x++;
-					printf("#%ld: %s\n", x, name.c_str());
-					consoleUpdate(NULL);
-				}
-				else break;
-			}
-			delete[] buffer;
-			break;
-		}
-		i++;
-	}
-	printf("Mapping %ld / %ld\r", i+1, mappings_count);
-	consoleUpdate(NULL);
-	MemoryInfo main = {0};
-	dmntchtQueryCheatProcessMemory(&main, cheatMetadata.main_nso_extents.base);
-	while (i < mappings_count) {
-		if ((memoryInfoBuffers[i].perm & Perm_Rw) == Perm_Rw && (memoryInfoBuffers[i].type == MemType_CodeMutable || memoryInfoBuffers[i].type == MemType_CodeWritable)) {
-			printf("Mapping %ld / %ld\r", i+1, mappings_count);
-			consoleUpdate(NULL);
-			if (memoryInfoBuffers[i].size > 200'000'000) {
-				i++;
-				continue;
-			}
-			uint64_t* buffer = new uint64_t[memoryInfoBuffers[i].size / sizeof(uint64_t)];
-			dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void*)buffer, memoryInfoBuffers[i].size);
-			uint16_t count = 0;
-			size_t start_index = 0;
-			for (size_t x = 0; x < (memoryInfoBuffers[i].size / sizeof(uint64_t)); x++) {
-				if (buffer[x] == 0 || (buffer[x] < main.addr) || (buffer[x] > (main.addr + main.size))) {
-					if (count == UnityNames.size()) {
-						start_index = x - count;
-						break;
-					}
-					count = 0;
-					continue;
-				}
-				count++;
-			}
-			if (count != UnityNames.size()) {
-				delete[] buffer;
-				i++;
-				continue;
-			}
-			for (size_t x = 0; x < count; x++) {
-				UnityOffsets.push_back(buffer[start_index + x] - cheatMetadata.main_nso_extents.base);
-			}
-			delete[] buffer;
-			printf("Found %ld Unity functions.\n", UnityNames.size());
-			return;
-		}
-		i++;
-	}
-	return;
+void searchFunctionsUnity2()
+{
+    size_t i = 0;
+    const char first_entry[] = "UnityEngineInternal.GIDebugVisualisation::ResetRuntimeInputTextures";
+    const char second_entry[] = "UnityEngineInternal.GIDebugVisualisation::PlayCycleMode";
+    const char *first_result = 0;
+    const char *second_result = 0;
+    Console::Printf("Base address: 0x%lx\n", cheatMetadata.main_nso_extents.base);
+    Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+    while (i < mappings_count)
+    {
+        if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx &&
+            (memoryInfoBuffers[i].type == MemType_CodeStatic || memoryInfoBuffers[i].type == MemType_CodeReadOnly))
+        {
+            Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+            if (memoryInfoBuffers[i].size > 200'000'000)
+            {
+                i++;
+                continue;
+            }
+            char *buffer_c = new char[memoryInfoBuffers[i].size];
+            dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void *)buffer_c, memoryInfoBuffers[i].size);
+            char *result = 0;
+            result = findStringInBuffer(buffer_c, memoryInfoBuffers[i].size, first_entry);
+            if (result)
+            {
+                first_result = (char *)(memoryInfoBuffers[i].addr + (result - buffer_c));
+                Console::Printf("Found 1. reference string at address 0x%lx\n", (uint64_t)first_result);
+                result = findStringInBuffer(buffer_c, memoryInfoBuffers[i].size, second_entry);
+                if (result)
+                {
+                    second_result = (char *)(memoryInfoBuffers[i].addr + (result - buffer_c));
+                    Console::Printf("Found 2. reference string at address 0x%lx\n", (uint64_t)second_result);
+                    delete[] buffer_c;
+                    break;
+                }
+            }
+            delete[] buffer_c;
+        }
+        i++;
+    }
+    if (!first_result || !second_result)
+    {
+        Console::Printf("Reference strings were not found! Aborting...\n");
+        return;
+    }
+    Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+    while (i < mappings_count)
+    {
+        if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx &&
+            (memoryInfoBuffers[i].type == MemType_CodeStatic || memoryInfoBuffers[i].type == MemType_CodeReadOnly))
+        {
+            Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+            if (memoryInfoBuffers[i].size > 200'000'000)
+            {
+                i++;
+                continue;
+            }
+            int32_t *buffer = new int32_t[memoryInfoBuffers[i].size / sizeof(int32_t)];
+            Console::Printf("Buffer: 0x%lx, size: 0x%lx\n", (uint64_t)buffer, memoryInfoBuffers[i].size);
+            dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void *)buffer, memoryInfoBuffers[i].size);
+            int32_t *result = 0;
+            for (size_t x = 0; x + 1 < memoryInfoBuffers[i].size / sizeof(uint32_t); x++)
+            {
+                int32_t diff1 = (int64_t)first_result - (memoryInfoBuffers[i].addr + (x * sizeof(uint32_t)));
+                int32_t diff2 = (int64_t)second_result - (memoryInfoBuffers[i].addr + (x * sizeof(uint32_t)));
+                if (buffer[x] == diff1 && buffer[x + 1] == diff2)
+                {
+                    result = &buffer[x];
+                    break;
+                }
+            }
+            if (!result)
+            {
+                delete[] buffer;
+                i++;
+                continue;
+            }
+            Console::Printf("Found string array at buffer address: 0x%lx\n", (uint64_t)result);
+            size_t x = 0;
+            while (true)
+            {
+                int32_t offset = result[x];
+                char *address = (char *)((uint64_t)result + offset);
+                if (((uint64_t)address > (uint64_t)buffer + memoryInfoBuffers[i].size) || ((uint64_t)address < (uint64_t)buffer))
+                {
+                    break;
+                }
+                if (!strncmp(address, "Unity", 5))
+                {
+                    std::string name = address;
+                    UnityNames.push_back(name);
+                    x++;
+                    Console::Printf("#%ld: %s\n", x, name.c_str());
+                }
+                else
+                    break;
+            }
+            delete[] buffer;
+            break;
+        }
+        i++;
+    }
+    Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+    MemoryInfo main = {0};
+    dmntchtQueryCheatProcessMemory(&main, cheatMetadata.main_nso_extents.base);
+    while (i < mappings_count)
+    {
+        if ((memoryInfoBuffers[i].perm & Perm_Rw) == Perm_Rw &&
+            (memoryInfoBuffers[i].type == MemType_CodeMutable || memoryInfoBuffers[i].type == MemType_CodeWritable))
+        {
+            Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+            if (memoryInfoBuffers[i].size > 200'000'000)
+            {
+                i++;
+                continue;
+            }
+            uint64_t *buffer = new uint64_t[memoryInfoBuffers[i].size / sizeof(uint64_t)];
+            dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void *)buffer, memoryInfoBuffers[i].size);
+            uint16_t count = 0;
+            size_t start_index = 0;
+            for (size_t x = 0; x < (memoryInfoBuffers[i].size / sizeof(uint64_t)); x++)
+            {
+                if (buffer[x] == 0 || (buffer[x] < main.addr) || (buffer[x] > (main.addr + main.size)))
+                {
+                    if (count == UnityNames.size())
+                    {
+                        start_index = x - count;
+                        break;
+                    }
+                    count = 0;
+                    continue;
+                }
+                count++;
+            }
+            if (count != UnityNames.size())
+            {
+                delete[] buffer;
+                i++;
+                continue;
+            }
+            for (size_t x = 0; x < count; x++)
+            {
+                UnityOffsets.push_back(buffer[start_index + x] - cheatMetadata.main_nso_extents.base);
+            }
+            delete[] buffer;
+            Console::Printf("Found %ld Unity functions.\n", UnityNames.size());
+            return;
+        }
+        i++;
+    }
+    return;
 }
 
-void searchFunctionsUnity() {
-	size_t i = 0;
-	const char first_entry[] = "UnityEngineInternal.GIDebugVisualisation::ResetRuntimeInputTextures";
-	printf("Base address: 0x%lx\n", cheatMetadata.main_nso_extents.base);
-	printf("Mapping %ld / %ld\r", i+1, mappings_count);
-	consoleUpdate(NULL);
-	char* found_string = 0;
-	while (i < mappings_count) {
-		if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx && (memoryInfoBuffers[i].type == MemType_CodeStatic || memoryInfoBuffers[i].type == MemType_CodeReadOnly)) {
-			printf("Mapping %ld / %ld\r", i+1, mappings_count);
-			consoleUpdate(NULL);
-			if (memoryInfoBuffers[i].size > 200'000'000) {
-				i++;
-				continue;
-			}
-			char* buffer_c = new char[memoryInfoBuffers[i].size];
-			dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void*)buffer_c, memoryInfoBuffers[i].size);
-			char* result = 0;
-			result = findStringInBuffer(buffer_c, memoryInfoBuffers[i].size, first_entry);
-			if (result) {
-				found_string = (char*)(memoryInfoBuffers[i].addr + (result - buffer_c));
-				printf("Found reference string at offset 0x%lx\n", (uint64_t)found_string);
-				consoleUpdate(NULL);
-				delete[] buffer_c;
-				break;
-			}
-			delete[] buffer_c;
-		}
-		i++;
-	}
-	if (!found_string) {
-		printf("Didn't found reference string.\n");
-		consoleUpdate(NULL);
-		return;
-	}
-	i = 0;
-	uint64_t* array_start = 0;
-	printf("Mapping %ld / %ld\r", i+1, mappings_count);
-	consoleUpdate(NULL);
-	while (i < mappings_count) {
-		if ((memoryInfoBuffers[i].perm & Perm_Rw) == Perm_Rw && (memoryInfoBuffers[i].type == MemType_CodeMutable || memoryInfoBuffers[i].type == MemType_CodeWritable)) {
-			printf("Mapping %ld / %ld\r", i+1, mappings_count);
-			consoleUpdate(NULL);
-			if (memoryInfoBuffers[i].size > 200'000'000) {
-				i++;
-				continue;
-			}
-			uint64_t* buffer = new uint64_t[memoryInfoBuffers[i].size / sizeof(uint64_t)];
-			dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void*)buffer, memoryInfoBuffers[i].size);
-			uint64_t* result = 0;
-			for (size_t x = 0; x < memoryInfoBuffers[i].size / sizeof(uint64_t); x++) {
-				if (buffer[x] == (uint64_t)found_string) {
-					result = (uint64_t*)(memoryInfoBuffers[i].addr + (sizeof(uint64_t) * x));
-					break;
-				}
-			}
-			delete[] buffer;
-			if (result) {
-				array_start = result;
-				printf("Found string array at offset 0x%lx\n", (uint64_t)array_start);
-				break;
-			}
-		}
-		i++;
-	}
-	if (!array_start) {
-		printf("Didn't found array string. Initiating second method...\n");
-		consoleUpdate(NULL);
-		return searchFunctionsUnity2();
-	}
-	i = 0;
-	while(true) {
-		uint64_t address = (u64)array_start + (i * 8);
-		uint64_t string_address = 0;
-		dmntchtReadCheatProcessMemory(address, (void*)&string_address, sizeof(uint64_t));
-		i++;
-		char UnityCheck[6] = "";
-		dmntchtReadCheatProcessMemory(string_address, (void*)UnityCheck, 5);
-		if (!strncmp(UnityCheck, "Unity", 5)) {
-			char buffer[1024] = "";
-			dmntchtReadCheatProcessMemory(string_address, (void*)buffer, 1024);
-			std::string string = buffer;
-			if (string.length() > 0) {
-				UnityNames.push_back(string);
-				printf("#%ld: %s\n", UnityNames.size(), UnityNames.back().c_str());
-				consoleUpdate(NULL);				
-			}
-		}
-		else break;
-	}
-	printf("Found %ld Unity functions.\n", UnityNames.size());
-	consoleUpdate(NULL);
-	uint64_t second_array = (u64)array_start + ((i-1) * 8);
-	for (size_t x = 0; x < UnityNames.size(); x++) {
-		uint64_t address = second_array + (x * 8);
-		uint64_t function_address = 0;
-		if (dmntchtReadCheatProcessMemory(address, (void*)&function_address, sizeof(uint64_t))) {
-			printf("Something went wrong.\n");
-			break;
-		}
-		UnityOffsets.push_back(function_address - cheatMetadata.main_nso_extents.base);
-	}
-	return;
+void searchFunctionsUnity()
+{
+    size_t i = 0;
+    const char first_entry[] = "UnityEngineInternal.GIDebugVisualisation::ResetRuntimeInputTextures";
+    Console::Printf("Base address: 0x%lx\n", cheatMetadata.main_nso_extents.base);
+    Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+    char *found_string = 0;
+    while (i < mappings_count)
+    {
+        if ((memoryInfoBuffers[i].perm & Perm_R) == Perm_R && (memoryInfoBuffers[i].perm & Perm_Rx) != Perm_Rx &&
+            (memoryInfoBuffers[i].type == MemType_CodeStatic || memoryInfoBuffers[i].type == MemType_CodeReadOnly))
+        {
+            Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+            if (memoryInfoBuffers[i].size > 200'000'000)
+            {
+                i++;
+                continue;
+            }
+            char *buffer_c = new char[memoryInfoBuffers[i].size];
+            dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void *)buffer_c, memoryInfoBuffers[i].size);
+            char *result = 0;
+            result = findStringInBuffer(buffer_c, memoryInfoBuffers[i].size, first_entry);
+            if (result)
+            {
+                found_string = (char *)(memoryInfoBuffers[i].addr + (result - buffer_c));
+                Console::Printf("Found reference string at offset 0x%lx\n", (uint64_t)found_string);
+                delete[] buffer_c;
+                break;
+            }
+            delete[] buffer_c;
+        }
+        i++;
+    }
+    if (!found_string)
+    {
+        Console::Printf("Didn't found reference string.\n");
+        return;
+    }
+    i = 0;
+    uint64_t *array_start = 0;
+    Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+    while (i < mappings_count)
+    {
+        if ((memoryInfoBuffers[i].perm & Perm_Rw) == Perm_Rw &&
+            (memoryInfoBuffers[i].type == MemType_CodeMutable || memoryInfoBuffers[i].type == MemType_CodeWritable))
+        {
+            Console::Printf("Mapping %ld / %ld\r", i + 1, mappings_count);
+            if (memoryInfoBuffers[i].size > 200'000'000)
+            {
+                i++;
+                continue;
+            }
+            uint64_t *buffer = new uint64_t[memoryInfoBuffers[i].size / sizeof(uint64_t)];
+            dmntchtReadCheatProcessMemory(memoryInfoBuffers[i].addr, (void *)buffer, memoryInfoBuffers[i].size);
+            uint64_t *result = 0;
+            for (size_t x = 0; x < memoryInfoBuffers[i].size / sizeof(uint64_t); x++)
+            {
+                if (buffer[x] == (uint64_t)found_string)
+                {
+                    result = (uint64_t *)(memoryInfoBuffers[i].addr + (sizeof(uint64_t) * x));
+                    break;
+                }
+            }
+            delete[] buffer;
+            if (result)
+            {
+                array_start = result;
+                Console::Printf("Found string array at offset 0x%lx\n", (uint64_t)array_start);
+                break;
+            }
+        }
+        i++;
+    }
+    if (!array_start)
+    {
+        Console::Printf("Didn't found array string. Initiating second method...\n");
+        return searchFunctionsUnity2();
+    }
+    i = 0;
+    while (true)
+    {
+        uint64_t address = (u64)array_start + (i * 8);
+        uint64_t string_address = 0;
+        dmntchtReadCheatProcessMemory(address, (void *)&string_address, sizeof(uint64_t));
+        i++;
+        char UnityCheck[6] = "";
+        dmntchtReadCheatProcessMemory(string_address, (void *)UnityCheck, 5);
+        if (!strncmp(UnityCheck, "Unity", 5))
+        {
+            char buffer[1024] = "";
+            dmntchtReadCheatProcessMemory(string_address, (void *)buffer, 1024);
+            std::string string = buffer;
+            if (string.length() > 0)
+            {
+                UnityNames.push_back(string);
+                Console::Printf("#%ld: %s\n", UnityNames.size(), UnityNames.back().c_str());
+            }
+        }
+        else
+            break;
+    }
+    Console::Printf("Found %ld Unity functions.\n", UnityNames.size());
+    uint64_t second_array = (u64)array_start + ((i - 1) * 8);
+    for (size_t x = 0; x < UnityNames.size(); x++)
+    {
+        uint64_t address = second_array + (x * 8);
+        uint64_t function_address = 0;
+        if (dmntchtReadCheatProcessMemory(address, (void *)&function_address, sizeof(uint64_t)))
+        {
+            Console::Printf("Something went wrong.\n");
+            break;
+        }
+        UnityOffsets.push_back(function_address - cheatMetadata.main_nso_extents.base);
+    }
+    return;
 }
 
 char path[128] = "";
 
-void dumpAsLog() {
-	if (UnityNames.size() != UnityOffsets.size()) {
-		printf("Cannot produce log, Names and Offsets count doesn't match.\n");
-		return;
-	}
-	uint64_t BID = 0;
-	memcpy(&BID, &(cheatMetadata.main_nso_build_id), 8);
-	mkdir("sdmc:/switch/UnityFuncDumper/", 777);
-	snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/", cheatMetadata.title_id);
-	mkdir(path, 777);
-	snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/%016lX.log", cheatMetadata.title_id, __builtin_bswap64(BID));	
-	FILE* text_file = fopen(path, "w");
-	if (!text_file) {
-		printf("Couldn't create log file!\n");
-		return;
-	}
-	fwrite(unity_sdk.c_str(), unity_sdk.size(), 1, text_file);
-	fwrite("\n\n", 2, 1, text_file);
-	for (size_t i = 0; i < UnityNames.size(); i++) {
-		fwrite(UnityNames[i].c_str(), UnityNames[i].length(), 1, text_file);
-		fwrite(": ", 2, 1, text_file);
-		char temp[128] = "";
-		snprintf(temp, sizeof(temp), "0x%X\n", UnityOffsets[i]);
-		fwrite(temp, strlen(temp), 1, text_file);
-	}
-	fclose(text_file);
-	printf("Dumped log file to:\n");
-	printf(path);	
-	printf("\n");
+void dumpAsLog()
+{
+    if (UnityNames.size() != UnityOffsets.size())
+    {
+        Console::Printf("Cannot produce log, Names and Offsets count doesn't match.\n");
+        return;
+    }
+    uint64_t BID = 0;
+    memcpy(&BID, &(cheatMetadata.main_nso_build_id), 8);
+    mkdir("sdmc:/switch/UnityFuncDumper/", 777);
+    snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/", cheatMetadata.title_id);
+    mkdir(path, 777);
+    snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/%016lX.log", cheatMetadata.title_id, __builtin_bswap64(BID));
+    FILE *text_file = fopen(path, "w");
+    if (!text_file)
+    {
+        Console::Printf("Couldn't create log file!\n");
+        return;
+    }
+    fwrite(unity_sdk.c_str(), unity_sdk.size(), 1, text_file);
+    fwrite("\n\n", 2, 1, text_file);
+    for (size_t i = 0; i < UnityNames.size(); i++)
+    {
+        fwrite(UnityNames[i].c_str(), UnityNames[i].length(), 1, text_file);
+        fwrite(": ", 2, 1, text_file);
+        char temp[128] = "";
+        snprintf(temp, sizeof(temp), "0x%X\n", UnityOffsets[i]);
+        fwrite(temp, strlen(temp), 1, text_file);
+    }
+    fclose(text_file);
+    Console::Printf("Dumped log file to:\n");
+    Console::Printf(path);
+    Console::Printf("\n");
 }
 
 // Main program entrypoint
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
-	// This example uses a text console, as a simple way to output text to the screen.
-	// If you want to write a software-rendered graphics application,
-	//   take a look at the graphics/simplegfx example, which uses the libnx Framebuffer API instead.
-	// If on the other hand you want to write an OpenGL based application,
-	//   take a look at the graphics/opengl set of examples, which uses EGL instead.
-	consoleInit(NULL);
+    // This example uses a text console, as a simple way to output text to the screen.
+    // If you want to write a software-rendered graphics application,
+    //   take a look at the graphics/simplegfx example, which uses the libnx Framebuffer API instead.
+    // If on the other hand you want to write an OpenGL based application,
+    //   take a look at the graphics/opengl set of examples, which uses EGL instead.
+    // None of that is true anymore SDL2
+    Logger::Initialize();
 
-	// Configure our supported input layout: a single player with standard controller styles
-	padConfigureInput(1, HidNpadStyleSet_NpadStandard);
+    if (!SDL::Initialize("UnityFuncDumper", 1280, 720))
+    {
+        Logger::Log("Error initializing SDL: %s", SDL::GetErrorString());
+    }
 
-	// Initialize the default gamepad (which reads handheld mode inputs as well as the first connected controller)
-	PadState pad;
-	padInitializeDefault(&pad);
+    if (!SDL::Text::Initialize())
+    {
+        Logger::Log("Error intializing SDL::Text: %s", SDL::GetErrorString());
+    }
 
-	bool error = false;
-	if (!isServiceRunning("dmnt:cht")) {
-		printf("DMNT:CHT not detected!\n");
-		error = true;
-	}
-	pmdmntInitialize();
-	uint64_t PID = 0;
-	if (R_FAILED(pmdmntGetApplicationProcessId(&PID))) {
-		printf("Game not initialized.\n");
-		error = true;
-	}
-	pmdmntExit();
-	if (error) {
-		printf("Press + to exit.");
-		while (appletMainLoop()) {   
-			// Scan the gamepad. This should be done once for each frame
-			padUpdate(&pad);
+    // This will add whatever character is passed as a special character to change the text color. I saw this thing prints something in blue at some point?
+    // SDLLib uses unions for colors instead of a struct. They must be assigned and passed like this: {0xRRGGBBAA}
+    SDL::Text::AddColorCharacter(L'^', {0x00FFFFFF});
 
-			// padGetButtonsDown returns the set of buttons that have been
-			// newly pressed in this frame compared to the previous one
-			u64 kDown = padGetButtonsDown(&pad);
+    // You can use this to set the Console's font size to whatever you want. The default text size in pixels is 20.
+    // Console::SetFontSize(20);
+    // This will set the maximum amount of lines for the console to display.
+    Console::SetMaxLineCount(27);
 
-			if (kDown & HidNpadButton_Plus)
-				break; // break in order to return to hbmenu
+    // Configure our supported input layout: a single player with standard controller styles
+    padConfigureInput(1, HidNpadStyleSet_NpadStandard);
 
-			// Your code goes here
+    // Initialize the default gamepad (which reads handheld mode inputs as well as the first connected controller)
+    PadState pad;
+    padInitializeDefault(&pad);
 
-			// Update the console, sending a new frame to the display
-			consoleUpdate(NULL);
-		}
-	}
-	else {
-		pmdmntExit();
-		size_t availableHeap = checkAvailableHeap();
-		printf("Available Heap: %ld MB\n", (availableHeap / (1024 * 1024)));
-		consoleUpdate(NULL);
-		dmntchtInitialize();
-		bool hasCheatProcess = false;
-		dmntchtHasCheatProcess(&hasCheatProcess);
-		if (!hasCheatProcess) {
-			dmntchtForceOpenCheatProcess();
-		}
+    bool error = false;
+    if (!isServiceRunning("dmnt:cht"))
+    {
+        Console::Printf("DMNT:CHT not detected!\n");
+        error = true;
+    }
+    pmdmntInitialize();
+    uint64_t PID = 0;
+    if (R_FAILED(pmdmntGetApplicationProcessId(&PID)))
+    {
+        Console::Printf("Game not initialized.\n");
+        error = true;
+    }
+    pmdmntExit();
+    if (error)
+    {
+        Console::Printf("Press + to exit.");
+        while (appletMainLoop())
+        {
+            // Scan the gamepad. This should be done once for each frame
+            padUpdate(&pad);
 
-		Result res = dmntchtGetCheatProcessMetadata(&cheatMetadata);
-		if (res)
-			printf("dmntchtGetCheatProcessMetadata ret: 0x%x\n", res);
+            // padGetButtonsDown returns the set of buttons that have been
+            // newly pressed in this frame compared to the previous one
+            u64 kDown = padGetButtonsDown(&pad);
 
-		res = dmntchtGetCheatProcessMappingCount(&mappings_count);
-		if (res)
-			printf("dmntchtGetCheatProcessMappingCount ret: 0x%x\n", res);
-		else printf("Mapping count: %ld\n", mappings_count);
+            if (kDown & HidNpadButton_Plus)
+                break; // break in order to return to hbmenu
 
-		memoryInfoBuffers = new MemoryInfo[mappings_count];
+            // Your code goes here
 
-		res = dmntchtGetCheatProcessMappings(memoryInfoBuffers, mappings_count, 0, &mappings_count);
-		if (res)
-			printf("dmntchtGetCheatProcessMappings ret: 0x%x\n", res);
+            // Update the console, sending a new frame to the display lol not anymore
+        }
+    }
+    else
+    {
+        pmdmntExit();
+        size_t availableHeap = checkAvailableHeap();
+        Console::Printf("Available Heap: %ld MB\n", (availableHeap / (1024 * 1024)));
+        dmntchtInitialize();
+        bool hasCheatProcess = false;
+        dmntchtHasCheatProcess(&hasCheatProcess);
+        if (!hasCheatProcess)
+        {
+            dmntchtForceOpenCheatProcess();
+        }
 
-		//Test run
+        Result res = dmntchtGetCheatProcessMetadata(&cheatMetadata);
+        if (res)
+            Console::Printf("dmntchtGetCheatProcessMetadata ret: 0x%x\n", res);
 
-		if (checkIfUnity()) {
+        res = dmntchtGetCheatProcessMappingCount(&mappings_count);
+        if (res)
+            Console::Printf("dmntchtGetCheatProcessMappingCount ret: 0x%x\n", res);
+        else
+            Console::Printf("Mapping count: %ld\n", mappings_count);
 
-			uint64_t BID = 0;
-			memcpy(&BID, &(cheatMetadata.main_nso_build_id), 8);
-			mkdir("sdmc:/switch/UnityFuncDumper/", 777);
-			snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/", cheatMetadata.title_id);
-			mkdir(path, 777);
-			snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/%016lX.log", cheatMetadata.title_id, __builtin_bswap64(BID));	
-			bool file_exists = false;
-			FILE* text_file = fopen(path, "r");
-			if (text_file) {
-				file_exists = true;
-				fclose(text_file);
-			}
-			if (file_exists) {
-				printf("\nFunctions offsets were already dumped.\nPress A to overwrite them.\nPress X to dump data.\nPress + to Exit\n\n");
-			}
-			else printf("\n----------\nPress A to Start\nPress + to Exit\n\n");
-			consoleUpdate(NULL);
-			bool overwrite = true;
-			while (appletMainLoop()) {   
-				padUpdate(&pad);
+        memoryInfoBuffers = new MemoryInfo[mappings_count];
 
-				u64 kDown = padGetButtonsDown(&pad);
+        res = dmntchtGetCheatProcessMappings(memoryInfoBuffers, mappings_count, 0, &mappings_count);
+        if (res)
+            Console::Printf("DmntchtGetCheatProcessMappings返回: 0x%x\n", res);
 
-				if (kDown & HidNpadButton_A)
-					break;
+        //Test run
 
-				if (kDown & HidNpadButton_Plus) {
-					dmntchtExit();
-					consoleExit(NULL);
-					return 0;
-				}
+        if (checkIfUnity())
+        {
 
-				if (file_exists && (kDown & HidNpadButton_X)) {
-					printf("Restoring offsets to program...\n");
-					consoleUpdate(NULL);
-					text_file = fopen(path, "r");
-					if (!text_file) {
-						printf("It didn't open?!\n");
-						consoleUpdate(NULL);
-					}
-					else {
-						char line[256] = "";
-						while (fgets(line, sizeof(line), text_file)) {
-							if (strncmp("Unity", line, 5))
-								continue;
-							char* ptr = strchr(line, ' ');
-							char temp[256] = "";
-							memcpy(temp, line, ptr-(line+1));
-							UnityOffsets.push_back(std::stoi(ptr, nullptr, 16));
-							UnityNames.push_back(temp);
-						}
-						fclose(text_file);
-					}
-					overwrite = false;
-					break;
-				}
-				
-			}
-			if (overwrite) {
-				printf("Searching RAM...\n\n");
-				consoleUpdate(NULL);
-				appletSetCpuBoostMode(ApmCpuBoostMode_FastLoad);
-				searchFunctionsUnity();
-				printf(CONSOLE_BLUE "\n---------------------------------------------\n\n" CONSOLE_RESET);
-				printf(CONSOLE_WHITE "Search is finished!\n");
-				consoleUpdate(NULL);
-				dumpAsLog();
-				appletSetCpuBoostMode(ApmCpuBoostMode_Normal);
-				delete[] memoryInfoBuffers;
-			}
-			dumpPointers(UnityNames, UnityOffsets, cheatMetadata, unity_sdk);
-		}
-		dmntchtExit();
-		printf("Press + to exit.");
-		while (appletMainLoop()) {   
-			// Scan the gamepad. This should be done once for each frame
-			padUpdate(&pad);
+            uint64_t BID = 0;
+            memcpy(&BID, &(cheatMetadata.main_nso_build_id), 8);
+            mkdir("sdmc:/switch/UnityFuncDumper/", 777);
+            snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/", cheatMetadata.title_id);
+            mkdir(path, 777);
+            snprintf(path, sizeof(path), "sdmc:/switch/UnityFuncDumper/%016lX/%016lX.log", cheatMetadata.title_id, __builtin_bswap64(BID));
+            bool file_exists = false;
+            FILE *text_file = fopen(path, "r");
+            if (text_file)
+            {
+                file_exists = true;
+                fclose(text_file);
+            }
+            if (file_exists)
+            {
+                Console::Printf("\nFunctions offsets were already dumped.\nPress \uE0E0 to overwrite them.\nPress \uE0E2 to dump data.\nPress "
+                                "\uE0EF to Exit\n\n");
+            }
+            else
+                Console::Printf("\n----------\nPress \uE0E0 to Start\nPress \uE0EF to Exit\n\n");
+            bool overwrite = true;
+            while (appletMainLoop())
+            {
+                padUpdate(&pad);
 
-			// padGetButtonsDown returns the set of buttons that have been
-			// newly pressed in this frame compared to the previous one
-			u64 kDown = padGetButtonsDown(&pad);
+                u64 kDown = padGetButtonsDown(&pad);
 
-			if (kDown & HidNpadButton_Plus)
-				break; // break in order to return to hbmenu
+                if (kDown & HidNpadButton_A)
+                    break;
 
-			// Your code goes here
+                if (kDown & HidNpadButton_Plus)
+                {
+                    dmntchtExit();
+                    consoleExit(NULL);
+                    return 0;
+                }
 
-			// Update the console, sending a new frame to the display
-			consoleUpdate(NULL);
-		}
-	}
+                if (file_exists && (kDown & HidNpadButton_X))
+                {
+                    Console::Printf("Restoring offsets to program...\n");
+                    text_file = fopen(path, "r");
+                    if (!text_file)
+                    {
+                        Console::Printf("It didn't open?!\n");
+                    }
+                    else
+                    {
+                        char line[256] = "";
+                        while (fgets(line, sizeof(line), text_file))
+                        {
+                            if (strncmp("Unity", line, 5))
+                                continue;
+                            char *ptr = strchr(line, ' ');
+                            char temp[256] = "";
+                            memcpy(temp, line, ptr - (line + 1));
+                            UnityOffsets.push_back(std::stoi(ptr, nullptr, 16));
+                            UnityNames.push_back(temp);
+                        }
+                        fclose(text_file);
+                    }
+                    overwrite = false;
+                    break;
+                }
+            }
+            if (overwrite)
+            {
+                Console::Printf("Searching RAM...\n\n");
+                appletSetCpuBoostMode(ApmCpuBoostMode_FastLoad);
+                searchFunctionsUnity();
+                Console::Printf("\n^---------------------------------------------^\n\nSearch finished!\n");
+                dumpAsLog();
+                appletSetCpuBoostMode(ApmCpuBoostMode_Normal);
+                delete[] memoryInfoBuffers;
+            }
+            dumpPointers(UnityNames, UnityOffsets, cheatMetadata, unity_sdk);
+        }
+        dmntchtExit();
+        Console::Printf("Press \uE0EF to exit.");
+        while (appletMainLoop())
+        {
+            // Scan the gamepad. This should be done once for each frame
+            padUpdate(&pad);
 
-	// Deinitialize and clean up resources used by the console (important!)
-	UnityNames.clear();
-	UnityOffsets.clear();
-	consoleExit(NULL);
-	return 0;
+            // padGetButtonsDown returns the set of buttons that have been
+            // newly pressed in this frame compared to the previous one
+            u64 kDown = padGetButtonsDown(&pad);
+
+            if (kDown & HidNpadButton_Plus)
+                break; // break in order to return to hbmenu
+
+            // Your code goes here
+
+            // Update the console, sending a new frame to the display lol
+        }
+    }
+
+    // Deinitialize and clean up resources used by the console (important!)
+    // There's no need to clear vectors like this. It's going to happen any way when they go out of scope or the program ends.
+    // UnityNames.clear();
+    // UnityOffsets.clear();
+    SDL::Text::Exit();
+    SDL::Exit();
+    return 0;
 }


### PR DESCRIPTION
Here's what I've done for you:
1. Added SDLLib as a submodule which allows a modified version of biggestDump's console to replace the default LibNX console which:
    * Allows you to print any character the Switch's shared font supports.
    * Allows you to actually be able read the text on the screen.
    * Allows you to easily highlight text for errors and other things. I've done it in a few places so you can see how it works.
2. Removed every call to `consoleUpdate` after `printf` was called to update the screen. This was everywhere instead of being wrapped in a single function that did both with one call.
3. Fixed two areas where `printf` was called multiple times for what could have been done in one call. That's what I caught. There could be more.
4. `wrongOperand` now takes a const reference to cheatMetaData instead of making a copy of it.
5. `dumpPointers` now takes const references to the vectors, struct, and string needed instead wasting time and memory making copies of them to pass.
6. Updated the `Makefile` to build everything, link correctly, and added a send target to use nxlink to send it to the homebrew menu.

With that out of the way, while everything seems fine on my end I will warn you that:
1. I went through as carefully as I could with the replace tool and used that to replace `printf` with `Console::Printf`. If anything seems off or wrong, you know how to contact me to take a look. Unfortunately, and honestly, the code in this project is really difficult to follow and read. 
2. There are several things I would definitely do differently, change, and cleanup if I had time, but I don't. 

This should be enough for you to translate the strings. Search the files for `Console::Printf`. Those are the strings displayed you need to translate. Like I said, reach out if anything is wrong. I'll get back to you as soon as I can.